### PR TITLE
feat: add coinomo to partners

### DIFF
--- a/yearn/partners/partners.py
+++ b/yearn/partners/partners.py
@@ -3,6 +3,17 @@ from yearn.partners.snapshot import Partner, Wrapper
 
 partners = [
     Partner(
+        name='coinomo',
+        treasury='0xd3877d9df3cb52006b7d932e8db4b36e22e89242',
+        wrappers=[
+            Wrapper(
+                name='yvUSDC',
+                vault='0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9',
+                wrapper='0xd3877d9df3cb52006b7d932e8db4b36e22e89242',
+            ),
+        ],
+    ),
+    Partner(
         name='alchemix',
         treasury='0x8392F6669292fA56123F71949B52d883aE57e225',
         wrappers=[


### PR DESCRIPTION
Coinomo (previously Cappuu) is a crypto wallet for retail users that let you easily deposit USD to USDC, using DeFi to earn yields and exchange cryptos.