### PR TITLE
fix: calculated apy using max of week ago and month ago apy [WEB-361]

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -51,3 +51,9 @@ def lusd():
     address = "0xA74d4B67b3368E83797a35382AFB776bAAE4F5C8"
     vault = VaultV2.from_address(address)
     print(json.dumps(dataclasses.asdict(vault.apy(samples)), indent=2))
+
+def rai():
+    samples = get_samples()
+    address = "0x873fB544277FD7b977B196a826459a69E27eA4ea"
+    vault = VaultV2.from_address(address)
+    print(json.dumps(dataclasses.asdict(vault.apy(samples)), indent=2))

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -53,7 +53,7 @@ def simple(vault, samples: ApySamples) -> Apy:
     inception_apy = calculate_roi(now_point, inception_point)
 
     # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy)
+    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
 
     strategy = vault.strategy
     withdrawal = strategy.withdrawalFee() if hasattr(strategy, "withdrawalFee") else 0

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -52,7 +52,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    net_apy = month_ago_apy
+    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
+    net_apy = max(month_ago_apy, week_ago_apy)
 
     strategy = vault.strategy
     withdrawal = strategy.withdrawalFee() if hasattr(strategy, "withdrawalFee") else 0

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -52,7 +52,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    apys = [week_ago_apy, month_ago_apy, inception_apy] # ordered by precedence
+    # use the first non-zero apy, ordered by precedence
+    apys = [week_ago_apy, month_ago_apy, inception_apy] 
     net_apy = next((value for value in apys if value != 0), 0)
 
     strategy = vault.strategy

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -52,8 +52,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
+    apys = [week_ago_apy, month_ago_apy, inception_apy] # ordered by precedence
+    net_apy = next((value for value in apys if value != 0), 0)
 
     strategy = vault.strategy
     withdrawal = strategy.withdrawalFee() if hasattr(strategy, "withdrawalFee") else 0

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -62,7 +62,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    net_apy = month_ago_apy
+    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
+    net_apy = max(month_ago_apy, week_ago_apy)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0
@@ -116,7 +117,8 @@ def average(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    net_apy = month_ago_apy
+    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
+    net_apy = max(month_ago_apy, week_ago_apy)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -63,7 +63,7 @@ def simple(vault, samples: ApySamples) -> Apy:
     inception_apy = calculate_roi(now_point, inception_point)
 
     # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy)
+    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0
@@ -118,7 +118,7 @@ def average(vault, samples: ApySamples) -> Apy:
     inception_apy = calculate_roi(now_point, inception_point)
 
     # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy)
+    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -62,8 +62,9 @@ def simple(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
+    # use the first non-zero apy, ordered by precedence
+    apys = [week_ago_apy, month_ago_apy, inception_apy] 
+    net_apy = next((value for value in apys if value != 0), 0)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0
@@ -117,8 +118,9 @@ def average(vault, samples: ApySamples) -> Apy:
     month_ago_apy = calculate_roi(now_point, month_ago_point)
     inception_apy = calculate_roi(now_point, inception_point)
 
-    # Default to higher sample as the result is largely dependent on number of harvests (usually one week sample is sufficient)
-    net_apy = max(month_ago_apy, week_ago_apy, inception_apy)
+    # use the first non-zero apy, ordered by precedence
+    apys = [week_ago_apy, month_ago_apy, inception_apy] 
+    net_apy = next((value for value in apys if value != 0), 0)
 
     # performance fee is doubled since 1x strategists + 1x treasury
     performance = (contract.performanceFee() * 2) if hasattr(contract, "performanceFee") else 0


### PR DESCRIPTION
Get this for the RAI vault now: 

<img width="618" alt="Screenshot 2021-06-21 at 17 14 42" src="https://user-images.githubusercontent.com/19509999/122795196-f9b0ec80-d2b4-11eb-8311-5a50433cb89c.png">
