### PR TITLE
fix: removed possibility of apr-after-fees being imaginary

### DIFF
--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -68,7 +68,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     compounding = 52
 
     # calculate our APR after fees
-    apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding
+    # if net_apy is negative no fees are charged
+    apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding if net_apy > 0 else net_apy
 
     # calculate our pre-fee APR
     gross_apr = apr_after_fees / (1 - performance)

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -133,7 +133,8 @@ def average(vault, samples: ApySamples) -> Apy:
     compounding = 52
 
     # calculate our APR after fees
-    apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding
+    # if net_apy is negative no fees are charged
+    apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding if net_apy > 0 else net_apy
 
     # calculate our pre-fee APR
     gross_apr = apr_after_fees / (1 - performance) + management


### PR DESCRIPTION
We were getting an imaginary number as the `apr_after_fees` for the gusd vault at `0xec0d8D3ED5477106c6D4ea27D90a60e594693C90` because `net_apy` was negative

`'gross_apr': (-0.852385187039765 + 3.093860710246853 j)`

I've changed `apr_after_fees` to be `net_apy` if this is the case, as we wouldn't be charging fees on a negative apy if I understand correctly