### PR TITLE
feat(apy): add ability to specify block for calculations

### DIFF
--- a/yearn/apy/common.py
+++ b/yearn/apy/common.py
@@ -63,9 +63,12 @@ def calculate_roi(after: SharePricePoint, before: SharePricePoint) -> float:
     return annualized
 
 
-def get_samples() -> ApySamples:
-    today = datetime.today()
-    now = web3.eth.block_number
-    week_ago = closest_block_after_timestamp((today - timedelta(days=7)).timestamp())
-    month_ago = closest_block_after_timestamp((today - timedelta(days=31)).timestamp())
+def get_samples(now_time: Optional[datetime] = None) -> ApySamples:
+    if now_time is None:
+        now_time = datetime.today()
+        now = web3.eth.block_number
+    else:
+        now = closest_block_after_timestamp(now_time.timestamp())
+    week_ago = closest_block_after_timestamp((now_time - timedelta(days=7)).timestamp())
+    month_ago = closest_block_after_timestamp((now_time - timedelta(days=31)).timestamp())
     return ApySamples(now, week_ago, month_ago)

--- a/yearn/apy/curve/rewards.py
+++ b/yearn/apy/curve/rewards.py
@@ -1,38 +1,41 @@
 from time import time
-
+from typing import Optional
 from brownie import Contract, ZERO_ADDRESS
 
 from yearn.apy.common import SECONDS_PER_YEAR
+from yearn.utils import get_block_timestamp
 
 from yearn.prices.magic import get_price
 
 
-def rewards(address: str, pool_price: int, base_asset_price: int) -> float:
+def rewards(address: str, pool_price: int, base_asset_price: int, block: Optional[int]=None) -> float:
     staking_rewards = Contract(address)
     if hasattr(staking_rewards, "periodFinish"):
-        return staking(address, pool_price, base_asset_price)
+        return staking(address, pool_price, base_asset_price, block=block)
     else:
-        return multi(address, pool_price, base_asset_price)
+        return multi(address, pool_price, base_asset_price, block=block)
 
 
-def staking(address: str, pool_price: int, base_asset_price: int) -> float:
+def staking(address: str, pool_price: int, base_asset_price: int, block: Optional[int]=None) -> float:
     staking_rewards = Contract(address)
-    end = staking_rewards.periodFinish()
-    if end < time():
+    end = staking_rewards.periodFinish(block_identifier=block)
+
+    current_time = time() if block is None else get_block_timestamp(block)
+    if end < current_time:
         return 0
 
-    snx_address = staking_rewards.snx() if hasattr(staking_rewards, "snx") else None
-    reward_token = staking_rewards.rewardToken() if hasattr(staking_rewards, "rewardToken") else None
-    rewards_token = staking_rewards.rewardsToken() if hasattr(staking_rewards, "rewardsToken") else None
+    snx_address = staking_rewards.snx(block_identifier=block) if hasattr(staking_rewards, "snx") else None
+    reward_token = staking_rewards.rewardToken(block_identifier=block) if hasattr(staking_rewards, "rewardToken") else None
+    rewards_token = staking_rewards.rewardsToken(block_identifier=block) if hasattr(staking_rewards, "rewardsToken") else None
 
     token = reward_token or rewards_token or snx_address
 
-    total_supply = staking_rewards.totalSupply() if hasattr(staking_rewards, "totalSupply") else 0
-    rate = staking_rewards.rewardRate() if hasattr(staking_rewards, "rewardRate") else 0
+    total_supply = staking_rewards.totalSupply(block_identifier=block) if hasattr(staking_rewards, "totalSupply") else 0
+    rate = staking_rewards.rewardRate(block_identifier=block) if hasattr(staking_rewards, "rewardRate") else 0
 
     if token and rate:
         # Single reward token
-        token_price = get_price(token)
+        token_price = get_price(token, block=block)
         return (SECONDS_PER_YEAR * (rate / 1e18) * token_price) / (
             (pool_price / 1e18) * (total_supply / 1e18) * base_asset_price
         )
@@ -41,48 +44,48 @@ def staking(address: str, pool_price: int, base_asset_price: int) -> float:
         queue = 0
         apr = 0
         try:
-            token = staking_rewards.rewardTokens(queue)
+            token = staking_rewards.rewardTokens(queue, block_identifier=block)
         except ValueError:
             token = None
         while token and token != ZERO_ADDRESS:
             try:
-                data = staking_rewards.rewardData(token)
+                data = staking_rewards.rewardData(token, block_identifier=block)
             except ValueError:
                 token = None
             rate = data.rewardRate / 1e18 if data else 0
-            token_price = get_price(token) or 0
+            token_price = get_price(token, block=block) or 0
             apr += SECONDS_PER_YEAR * rate * token_price / ((pool_price / 1e18) * (total_supply / 1e18) * token_price)
             queue += 1
             try:
-                token = staking_rewards.rewardTokens(queue)
+                token = staking_rewards.rewardTokens(queue, block_identifier=block)
             except ValueError:
                 token = None
         return apr
 
 
-def multi(address: str, pool_price: int, base_asset_price: int) -> float:
+def multi(address: str, pool_price: int, base_asset_price: int, block: Optional[int]=None) -> float:
     multi_rewards = Contract(address)
 
-    total_supply = multi_rewards.totalSupply() if hasattr(multi_rewards, "totalSupply") else 0
+    total_supply = multi_rewards.totalSupply(block_identifier=block) if hasattr(multi_rewards, "totalSupply") else 0
 
     queue = 0
     apr = 0
     if hasattr(multi_rewards, "rewardsToken"):
-        token = multi_rewards.rewardTokens(queue)
+        token = multi_rewards.rewardTokens(queue, block_identifier=block)
     else:
         token = None
     while token and token != ZERO_ADDRESS:
         try:
-            data = multi_rewards.rewardData(token)
+            data = multi_rewards.rewardData(token, block_identifier=block)
         except ValueError:
             token = None
         if data.periodFinish >= time():
             rate = data.rewardRate / 1e18 if data else 0
-            token_price = get_price(token) or 0
+            token_price = get_price(token, block=block) or 0
             apr += SECONDS_PER_YEAR * rate * token_price / ((pool_price / 1e18) * (total_supply / 1e18) * token_price)
         queue += 1
         try:
-            token = multi_rewards.rewardTokens(queue)
+            token = multi_rewards.rewardTokens(queue, block_identifier=block)
         except ValueError:
             token = None
     return apr

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -34,7 +34,7 @@ def simple(vault: VaultV2, samples: ApySamples) -> Apy:
     if len(harvests) < 4:
         raise ApyError("v2:harvests", "harvests are < 4")
 
-    now = harvests[-1]
+    now = closest(harvests, samples.now)
     week_ago = closest(harvests, samples.week_ago)
     month_ago = closest(harvests, samples.month_ago)
     inception_block = harvests[2]


### PR DESCRIPTION
The code was tested by
- Scraping https://api.yearn.finance/v1/chains/1/vaults/all for the past 15 days and data collected in 
[yearn_historical_apy.csv](https://github.com/yearn/yearn-exporter/files/6820340/yearn_historical_apy.csv)
- Running [script](https://gist.github.com/jainkunal/358e72c259e7dfda94a57689e4809b19) on the collected data and logging results in [validate.txt](https://github.com/yearn/yearn-exporter/files/6820351/validate.txt)

Usually the `net_apy` is <1% which was expected but at times, it does go as high as 40% which couldn't be explained.
