### PR TITLE
fix(ironbank): unknown tokens shouldn't crash the exporter

### DIFF
--- a/yearn/ironbank.py
+++ b/yearn/ironbank.py
@@ -63,8 +63,9 @@ class Registry:
             ],
             block=block,
         )
+
         prices = Parallel(8, "threading")(
-            delayed(magic.get_price)(market.underlying, block=block) for market in markets
+            delayed(magic.get_price_safe)(market.underlying, block=block) for market in markets
         )
         output = defaultdict(dict)
         for m, price in zip(markets, prices):
@@ -103,7 +104,10 @@ class Registry:
             ["getCash", "totalBorrows", "totalReserves", "totalSupply"],
             block=block,
         )
-        prices = Parallel(8, "threading")(delayed(magic.get_price)(market.vault, block=block) for market in markets)
+
+        prices = Parallel(8, "threading")(
+            delayed(magic.get_price_safe)(market.underlying, block=block) for market in markets
+        )
         results = [data[market.vault] for market in markets]
         return {
             # market.name: (res["getCash"] + res["totalBorrows"] - res["totalReserves"]) / 10 ** market.decimals * price

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -66,9 +66,7 @@ def get_price(token, block=None):
         price = uniswap.get_price_v1(token, block=block)
         logger.debug("uniswap v1 -> %s", price)
     if not price:
-        logger.error("failed to get price for %s", token)
-
-    if not price:
-        raise PriceError(f'could not fetch price for {token}')
+        price = 0
+        logger.error("failed to get price for %s, setting price=0", token)
 
     return price

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -66,7 +66,15 @@ def get_price(token, block=None):
         price = uniswap.get_price_v1(token, block=block)
         logger.debug("uniswap v1 -> %s", price)
     if not price:
-        price = 0
-        logger.error("failed to get price for %s, setting price=0", token)
+        logger.error("failed to get price for %s", token)
+        raise PriceError(f'could not fetch price for {token}')
 
+    return price
+
+def get_price_safe(token, block=None):
+    price = 0
+    try:
+        price = get_price(token, block)
+    except PriceError:
+        pass
     return price


### PR DESCRIPTION
Added a new `magic#get_price_safe` which always returns the price or 0 and use that in the ironbank calculations.
