### PR TITLE
fix(prices): use coingecko for non historical prices

### DIFF
--- a/yearn/prices/coingecko.py
+++ b/yearn/prices/coingecko.py
@@ -1,0 +1,16 @@
+import requests
+from cachetools.func import ttl_cache
+
+
+@ttl_cache(ttl=600)
+def get_price(asset, block=None):
+    if block is None:
+        params = {'contract_addresses': asset, 'vs_currencies': 'usd'}
+        r = requests.get("https://api.coingecko.com/api/v3/simple/token_price/ethereum", params)
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        return data[asset.lower()]["usd"]
+    else:
+        # Coingecko only returns current prices.
+        return None

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -2,7 +2,7 @@ import logging
 
 from cachetools.func import ttl_cache
 
-from yearn.prices import balancer, chainlink, compound, constants, curve, uniswap, yearn
+from yearn.prices import balancer, chainlink, compound, constants, curve, uniswap, coingecko, yearn
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,9 @@ def get_price(token, block=None):
     if not price:
         price = uniswap.get_price_v1(token, block=block)
         logger.debug("uniswap v1 -> %s", price)
+    if not price:
+        price = coingecko.get_price(token, block=block)
+        logger.debug("coingecko -> %s", price)
     if not price:
         logger.error("failed to get price for %s", token)
         raise PriceError(f'could not fetch price for {token}')


### PR DESCRIPTION
Adds ability to fetch instant prices from coingecko. If a block other than `None` is used to fetch prices, the call will return `None`.