### PR TITLE
Parallelization of historical exporter

### DIFF
--- a/grafana/provisioning/dashboards/system/exporters_duration.json
+++ b/grafana/provisioning/dashboards/system/exporters_duration.json
@@ -1,0 +1,196 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 22,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.1.5",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg_over_time(export_duration)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Panel Title",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_PROMETHEUS",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 22,
+        "w": 17,
+        "x": 6,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "export_duration",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:101",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:102",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-2y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "exporter_durations",
+  "uid": "Xt16eZvnk",
+  "version": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ aiofiles>=0.6.0
 semantic-version>=2.8.5
 boto3==1.17.88
 ypricemagic>=0.2.4
-more-itertools>=8.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ aiofiles>=0.6.0
 semantic-version>=2.8.5
 boto3==1.17.88
 ypricemagic>=0.2.4
+more-itertools>=8.10.0

--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -4,6 +4,7 @@ import time
 
 from brownie import chain
 from yearn.yearn import Yearn
+from yearn.outputs import victoria
 
 logger = logging.getLogger('yearn.exporter')
 sleep_interval = int(os.environ.get('SLEEP_SECONDS', '0'))
@@ -11,8 +12,12 @@ sleep_interval = int(os.environ.get('SLEEP_SECONDS', '0'))
 def main():
     yearn = Yearn()
     for block in chain.new_blocks(height_buffer=1):
+        start_time = time.time()
         yearn.export(block.number, block.timestamp)
+        duration = time.time() - start_time
+        victoria.export_duration(duration, 1, "forwards", block.timestamp)
         time.sleep(sleep_interval)
+
 
 def tvl():
     yearn = Yearn()

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -97,10 +97,6 @@ def _export_chunk(chunk):
 def _interval_export(yearn, snapshot):
     start_time = time.time()
     ts = snapshot.timestamp()
-    if _has_data(ts):
-        logger.info("data already present for snapshot %s, ts %d", snapshot, ts)
-        return
-
     block = closest_block_after_timestamp(ts)
     assert block is not None, "no block after timestamp found"
     yearn.export(block, ts)
@@ -128,6 +124,10 @@ def _has_data(ts):
 def _generate_snapshot_range(start, end, interval):
     for i in count():
         snapshot = start - i * interval
+        ts = snapshot.timestamp()
+        if _has_data(ts):
+            logger.info("data already present for snapshot %s, ts %d", snapshot, ts)
+            continue
         if snapshot < end:
             return
         else:

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -124,11 +124,12 @@ def _has_data(ts):
 def _generate_snapshot_range(start, end, interval):
     for i in count():
         snapshot = start - i * interval
-        ts = snapshot.timestamp()
-        if _has_data(ts):
-            logger.info("data already present for snapshot %s, ts %d", snapshot, ts)
-            continue
         if snapshot < end:
             return
         else:
-            yield snapshot
+            ts = snapshot.timestamp()
+            if _has_data(ts):
+                logger.info("data already present for snapshot %s, ts %d", snapshot, ts)
+                continue
+            else:
+                yield snapshot

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -28,14 +28,52 @@ def main():
 
     interval_map = [
         {
-          'start': start.replace(hour=0, minute=0, second=0, microsecond=0),
-          'interval': timedelta(days=1),
+            'resolution': '1d',
+            'start': start.replace(hour=0, minute=0, second=0, microsecond=0),
+            'interval': timedelta(days=1),
         },
         {
-          'start': start.replace(minute=0, second=0, microsecond=0),
-          'interval': timedelta(hours=1),
+            'resolution': '1h',
+            'start': start.replace(minute=0, second=0, microsecond=0),
+            'interval': timedelta(hours=1),
+        },
+        {
+            'resolution': '30m',
+            'start': start.replace(minute=0, second=0, microsecond=0),
+            'interval': timedelta(minutes=30),
+        },
+        {
+            'resolution': '15m',
+            'start': start.replace(minute=0, second=0, microsecond=0),
+            'interval': timedelta(minutes=15),
+        },
+        {
+            'resolution': '5m',
+            'start': start.replace(minute=0, second=0, microsecond=0),
+            'interval': timedelta(minutes=5),
+        },
+        {
+            'resolution': '1m',
+            'start': start.replace(second=0, microsecond=0),
+            'interval': timedelta(minutes=1),
+        },
+        {
+            'resolution': '30s',
+            'start': start.replace(second=0, microsecond=0),
+            'interval': timedelta(seconds=30),
+        },
+        {
+            'resolution': '15s',
+            'start': start.replace(second=0, microsecond=0),
+            'interval': timedelta(seconds=15),
         },
     ]
+
+    resolutions = [item['resolution'] for item in interval_map]
+    # default resolution is hourly
+    resolution = os.environ.get("RESOLUTION", "1h")
+    if resolution not in resolutions:
+        resolution = "1h"
 
     for entry in interval_map:
         intervals = _generate_snapshot_range(entry["start"], end, entry["interval"])
@@ -44,6 +82,10 @@ def main():
         Parallel(n_jobs=POOL_SIZE, backend="multiprocessing", verbose=100)(
             delayed(_export_chunk)(chunk) for chunk in partition_all(CHUNK_SIZE, intervals)
         )
+
+        # if we reached the final resolution we're done
+        if entry['resolution'] == resolution:
+            break
 
 
 def _export_chunk(chunk):

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -12,10 +12,12 @@ from more_itertools import chunked
 from joblib import Parallel, delayed
 import multiprocessing
 import requests
+import psutil
 
 logger = logging.getLogger('yearn.historical_exporter')
 
-default_pool_size = max(1, math.floor(multiprocessing.cpu_count() / 3))
+available_memory = psutil.virtual_memory().available / 1e9   # in GB
+default_pool_size = max(1, math.floor(available_memory / 8)) # allocate 8GB per worker
 POOL_SIZE = int(os.environ.get("POOL_SIZE", default_pool_size))
 CHUNK_SIZE = int(os.environ.get("CHUNK_SIZE", 50))
 

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -47,7 +47,7 @@ def main():
 
 
 def _export_chunk(chunk):
-    yearn = Yearn(watch_events=False)
+    yearn = Yearn(watch_events_forever=False)
     for interval in chunk:
         _interval_export(yearn, interval)
 

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -1,35 +1,57 @@
 import logging
 import os
 from datetime import datetime, timedelta, timezone
+import time
+import math
 
 from yearn.yearn import Yearn
+from yearn.outputs import victoria
 from yearn.utils import closest_block_after_timestamp
 from itertools import count
-
+from more_itertools import chunked
+from joblib import Parallel, delayed
+import multiprocessing
 import requests
 
 logger = logging.getLogger('yearn.historical_exporter')
 
+default_pool_size = max(1, math.floor(multiprocessing.cpu_count() / 3))
+POOL_SIZE = int(os.environ.get("POOL_SIZE", default_pool_size))
+CHUNK_SIZE = int(os.environ.get("CHUNK_SIZE", 50))
 
 def main():
     start = datetime.now(tz=timezone.utc)
     # end: 2020-02-12 first iearn deployment
     end = datetime(2020, 2, 12, tzinfo=timezone.utc)
 
-    yearn = Yearn()
+    interval_map = [
+        {
+          'start': start.replace(hour=0, minute=0, second=0, microsecond=0),
+          'interval': timedelta(days=1),
+        },
+        {
+          'start': start.replace(minute=0, second=0, microsecond=0),
+          'interval': timedelta(hours=1),
+        },
+    ]
 
-    start_daily = start.replace(hour=0, minute=0, second=0, microsecond=0)
-    daily = _generate_snapshot_range(start_daily, end, timedelta(days=1))
-    for day in daily:
-        _interval_export(yearn, day)
+    for entry in interval_map:
+        intervals = _generate_snapshot_range(entry["start"], end, entry["interval"])
 
-    start_hourly = start.replace(minute=0, second=0, microsecond=0)
-    hourly = _generate_snapshot_range(start_hourly, end, timedelta(hours=1))
-    for hour in hourly:
-        _interval_export(yearn, hour)
+        logger.info("starting new pool with %d workers", POOL_SIZE)
+        Parallel(n_jobs=POOL_SIZE, backend="multiprocessing", verbose=100)(
+            delayed(_export_chunk)(chunk) for chunk in chunked(intervals, CHUNK_SIZE)
+        )
+
+
+def _export_chunk(chunk):
+    yearn = Yearn(watch_events=False)
+    for interval in chunk:
+        _interval_export(yearn, interval)
 
 
 def _interval_export(yearn, snapshot):
+    start_time = time.time()
     ts = snapshot.timestamp()
     if _has_data(ts):
         logger.info("data already present for snapshot %s, ts %d", snapshot, ts)
@@ -38,6 +60,8 @@ def _interval_export(yearn, snapshot):
     block = closest_block_after_timestamp(ts)
     assert block is not None, "no block after timestamp found"
     yearn.export(block, ts)
+    duration = time.time() - start_time
+    victoria.export_duration(duration, POOL_SIZE, "historical", ts)
     logger.info("exported historical snapshot %s", snapshot)
 
 

--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -8,7 +8,7 @@ from yearn.yearn import Yearn
 from yearn.outputs import victoria
 from yearn.utils import closest_block_after_timestamp
 from itertools import count
-from more_itertools import chunked
+from toolz import partition_all
 from joblib import Parallel, delayed
 import multiprocessing
 import requests
@@ -42,7 +42,7 @@ def main():
 
         logger.info("starting new pool with %d workers", POOL_SIZE)
         Parallel(n_jobs=POOL_SIZE, backend="multiprocessing", verbose=100)(
-            delayed(_export_chunk)(chunk) for chunk in chunked(intervals, CHUNK_SIZE)
+            delayed(_export_chunk)(chunk) for chunk in partition_all(CHUNK_SIZE, intervals)
         )
 
 

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - ETHERSCAN_TOKEN
       - EXPLORER
       - SLEEP_SECONDS
+      - POOL_SIZE
+      - CHUNK_SIZE
     volumes:
       - solidity_compilers:/root/.solcx
       - vyper_compilers:/root/.vvm

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - SLEEP_SECONDS
       - POOL_SIZE
       - CHUNK_SIZE
+      - RESOLUTION
     volumes:
       - solidity_compilers:/root/.solcx
       - vyper_compilers:/root/.vvm

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - cache:/app/yearn-exporter/cache
     networks:
       - yearn-exporter
-    restart: always
+    restart: on-failure
 
   historical-exporter:
     build: .
@@ -49,7 +49,7 @@ services:
       - cache:/app/yearn-exporter/cache
     networks:
       - yearn-exporter
-    restart: always
+    restart: on-failure
 
   vmagent:
     image: victoriametrics/vmagent

--- a/yearn/config.py
+++ b/yearn/config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class Config:
-    watch_events: bool = True
+    watch_events_forever: bool = True
 
 
 config = Config()

--- a/yearn/config.py
+++ b/yearn/config.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class Config:
-    watch_events_forever: bool = True
-
-
-config = Config()

--- a/yearn/outputs/victoria.py
+++ b/yearn/outputs/victoria.py
@@ -84,9 +84,20 @@ def export(timestamp, data):
     _post(metrics_to_export)
 
 
+def export_duration(duration_seconds, pool_size, direction, timestamp_seconds):
+    item = _build_item(
+      "export_duration",
+      [ "pool_size", "direction" ],
+      [ pool_size, direction ],
+      duration_seconds,
+      timestamp_seconds
+    )
+    _post([item])
+
+
 def _build_item(metric, label_names, label_values, value, timestamp):
     ts_millis = math.floor(timestamp) * 1000
-    meta = dict(zip(map(_sanitize, label_names), label_values))
+    meta = dict(zip(map(_sanitize, label_names), map(str, label_values)))
     meta["__name__"] = metric
     return {"metric": meta, "values": [_sanitize(value)], "timestamps": [ts_millis]}
 

--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -12,6 +12,7 @@ from yearn.multicall2 import fetch_multicall
 from yearn.prices import magic
 from yearn.utils import contract_creation_block, Singleton
 from yearn.v2.vaults import Vault
+from yearn.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,8 @@ class Registry(metaclass=Singleton):
             if not self._done.is_set():
                 self._done.set()
                 logger.info("loaded v2 registry in %.3fs", time.time() - start)
+            if not config.watch_events_forever:
+                break
             time.sleep(300)
 
     def process_events(self, events):

--- a/yearn/v2/strategies.py
+++ b/yearn/v2/strategies.py
@@ -9,6 +9,7 @@ from eth_utils import encode_hex, event_abi_to_log_topic
 from yearn.utils import safe_views
 from yearn.multicall2 import fetch_multicall
 from yearn.events import create_filter, decode_logs
+from yearn.config import config
 
 
 STRATEGY_VIEWS_SCALED = [
@@ -77,6 +78,8 @@ class Strategy:
             if not self._done.is_set():
                 self._done.set()
                 logger.info("loaded %d harvests %s in %.3fs", len(self._harvests), self.name, time.time() - start)
+            if not config.watch_events_forever:
+                break
             time.sleep(300)
 
     def process_events(self, events):

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -19,6 +19,7 @@ from yearn.utils import safe_views
 from yearn.v2.strategies import Strategy
 from yearn.prices.curve import curve
 from yearn.apy.common import ApySamples
+from yearn.config import config
 
 VAULT_VIEWS_SCALED = [
     "totalAssets",
@@ -136,6 +137,8 @@ class Vault:
             if not self._done.is_set():
                 self._done.set()
                 logger.info("loaded %d strategies %s in %.3fs", len(self._strategies), self.name, time.time() - start)
+            if not config.watch_events_forever:
+                break
             time.sleep(300)
 
     def process_events(self, events):

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -19,7 +19,6 @@ from yearn.utils import safe_views
 from yearn.v2.strategies import Strategy
 from yearn.prices.curve import curve
 from yearn.apy.common import ApySamples
-from yearn.config import config
 
 VAULT_VIEWS_SCALED = [
     "totalAssets",
@@ -49,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 class Vault:
-    def __init__(self, vault, api_version=None, token=None, registry=None):
+    def __init__(self, vault, api_version=None, token=None, registry=None, watch_events_forever=True):
         self._strategies = {}
         self._revoked = {}
         self._reports = []
@@ -71,6 +70,7 @@ class Vault:
                 if event["type"] == "event" and event["name"] in STRATEGY_EVENTS
             ]
         ]
+        self._watch_events_forever = watch_events_forever
         self._done = threading.Event()
         self._thread = threading.Thread(target=self.watch_events, daemon=True)
 
@@ -137,7 +137,7 @@ class Vault:
             if not self._done.is_set():
                 self._done.set()
                 logger.info("loaded %d strategies %s in %.3fs", len(self._strategies), self.name, time.time() - start)
-            if not config.watch_events_forever:
+            if not self._watch_events_forever:
                 break
             time.sleep(300)
 
@@ -145,18 +145,18 @@ class Vault:
         for event in events:
             if event.name == "StrategyAdded":
                 logger.debug("%s strategy added %s", self.name, event["strategy"])
-                self._strategies[event["strategy"]] = Strategy(event["strategy"], self)
+                self._strategies[event["strategy"]] = Strategy(event["strategy"], self, self._watch_events_forever)
             elif event.name == "StrategyRevoked":
                 logger.debug("%s strategy revoked %s", self.name, event["strategy"])
                 self._revoked[event["strategy"]] = self._strategies.pop(
-                    event["strategy"], Strategy(event["strategy"], self)
+                    event["strategy"], Strategy(event["strategy"], self, self._watch_events_forever)
                 )
             elif event.name == "StrategyMigrated":
                 logger.debug("%s strategy migrated %s -> %s", self.name, event["oldVersion"], event["newVersion"])
                 self._revoked[event["oldVersion"]] = self._strategies.pop(
-                    event["oldVersion"], Strategy(event["oldVersion"], self)
+                    event["oldVersion"], Strategy(event["oldVersion"], self, self._watch_events_forever)
                 )
-                self._strategies[event["newVersion"]] = Strategy(event["newVersion"], self)
+                self._strategies[event["newVersion"]] = Strategy(event["newVersion"], self, self._watch_events_forever)
             elif event.name == "StrategyReported":
                 self._reports.append(event)
 

--- a/yearn/yearn.py
+++ b/yearn/yearn.py
@@ -9,6 +9,7 @@ import yearn.special
 import yearn.v2.registry
 import yearn.v1.registry
 from yearn.outputs import victoria
+from yearn.config import config
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class Yearn:
     Can describe all products.
     """
 
-    def __init__(self, load_strategies=True, load_harvests=False) -> None:
+    def __init__(self, load_strategies=True, load_harvests=False, watch_events=True) -> None:
         start = time()
         self.registries = {
             "earn": yearn.iearn.Registry(),
@@ -28,6 +29,7 @@ class Yearn:
             "ib": yearn.ironbank.Registry(),
             "special": yearn.special.Registry(),
         }
+        config.watch_events_forever = watch_events
         if load_strategies:
             self.registries["v2"].load_strategies()
         if load_harvests:

--- a/yearn/yearn.py
+++ b/yearn/yearn.py
@@ -9,7 +9,6 @@ import yearn.special
 import yearn.v2.registry
 import yearn.v1.registry
 from yearn.outputs import victoria
-from yearn.config import config
 
 
 logger = logging.getLogger(__name__)
@@ -20,16 +19,15 @@ class Yearn:
     Can describe all products.
     """
 
-    def __init__(self, load_strategies=True, load_harvests=False, watch_events=True) -> None:
+    def __init__(self, load_strategies=True, load_harvests=False, watch_events_forever=True) -> None:
         start = time()
         self.registries = {
             "earn": yearn.iearn.Registry(),
             "v1": yearn.v1.registry.Registry(),
-            "v2": yearn.v2.registry.Registry(),
+            "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
             "ib": yearn.ironbank.Registry(),
             "special": yearn.special.Registry(),
         }
-        config.watch_events_forever = watch_events
         if load_strategies:
             self.registries["v2"].load_strategies()
         if load_harvests:


### PR DESCRIPTION
With this PR I've implemented parallel computing for the historical exporter which speeds up the exports by a factor of `POOL_SIZE` .

The intervals that must be exported are chunked by `CHUNK_SIZE` and each chunk is passed to the worker.
In order to circumvent pickling of the yearn object, I had to re-initialize it in every `#export_chunk` invocation.
This makes it a bit slower by a constant time per chunk but it's acceptable imo.

I assumed a quite realistic memory footprint of `8GB` per worker and scale it up once at startup to the available ressources.
So if you have 20GB free memory it will allocate a joblib pool with 2 workers running in separate processes. The amount of workers can be overriden with the env variable `POOL_SIZE` but a too high value will cause memory to bloat up very fast and most certainly render the system irresponsive for a while :sweat_smile: 

Unfortunately, I couldn't use the shared memory semantics of joblib because that's thread-based and in my benchmarks this made it even worse than running sequentially.

I've also added a new dashboard under system where the actual export durations are measured for the `historical` and the `forwards` exporters. That makes it easier to experiment with the different values of `POOL_SIZE` and `CHUNK_SIZE` .

