### PR TITLE
fix: use crypto swap registry if available

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -127,3 +127,6 @@ def dai():
 
 def old_dai():
     calculate_apy("0x19D3364A399d251E894aC732651be8B0E4e85001")
+
+def eurs_usdc():
+    calculate_apy("0x801Ab06154Bf539dea4385a39f5fa8534fB53073")

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -136,7 +136,10 @@ class CurveRegistry(metaclass=Singleton):
         }
     
     def crypto_swap_registry_supports_pool(self, pool):
-        return self.crypto_swap_registry.get_pool_name(pool)
+        if self.crypto_swap_registry.get_pool_name(pool):
+            return True
+        else: 
+            return False
 
     def get_factory(self, pool):
         """


### PR DESCRIPTION
Fixes https://github.com/yearn/yearn-exporter/issues/187

Check to see if the 'CryptoSwap' registry can be used before falling back to the original registry

The crypto swap registry can be found at position 5 in the address provider