### PR TITLE
feat: magic.get_price for curve v2

### DIFF
--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -161,6 +161,13 @@ class CurveRegistry(metaclass=Singleton):
 
         if pool != ZERO_ADDRESS:
             return pool
+        
+        # Curve V2
+        token = contract(token)
+        if hasattr(token,'minter'):
+            minter = contract(token.minter())
+            if hasattr(minter,'admin_fee_receiver') or hasattr(minter,'admin_balances'): # Just a sense check
+                return minter.address
 
     @lru_cache(maxsize=None)
     def get_gauge(self, pool):


### PR DESCRIPTION
Cherry-picked this fix from @BobTheBuidler : 15e3d1d
for the curve v2 pool detection which failed for CRV-ETH:
`PriceError: could not fetch price for 0xEd4064f376cB8d68F770FB1Ff088a3d0F3FF5c4d at 13902829`