### PR TITLE
[WEB-1103-191] refactor(yearn/special): normalize casing of composite object of apy

### DIFF
--- a/yearn/special.py
+++ b/yearn/special.py
@@ -78,7 +78,7 @@ class Backscratcher:
         voter = "0xF147b8125d2ef93FB6965Db97D6746952a133934"
         crv_price = magic.get_price("0xD533a949740bb3306d119CC777fa900bA034cd52")
         yvecrv_price = magic.get_price("0xc5bDdf9843308380375a611c18B50Fb9341f502A")
-        
+
         total_vecrv = curve_voting_escrow.totalSupply()
         yearn_vecrv = curve_voting_escrow.balanceOf(voter)
         vault_supply = self.vault.totalSupply()
@@ -91,11 +91,11 @@ class Backscratcher:
         apy = (tokens_per_week * virtual_price * 52) / ((total_vecrv / 1e18) * crv_price)
         vault_boost = (yearn_vecrv / vault_supply) * (crv_price / yvecrv_price)
         composite = {
-            "currentBoost": vault_boost,
-            "boostedApy": apy * vault_boost,
-            "totalApy": apy * vault_boost,
-            "poolApy": apy,
-            "baseApy": apy,
+            "boost": vault_boost,
+            "boosted_apy": apy * vault_boost,
+            "total_apy": apy * vault_boost,
+            "pool_apy": apy,
+            "base_apy": apy,
         }
         return Apy("backscratcher", apy, apy, ApyFees(), composite=composite)
 
@@ -106,9 +106,9 @@ class Backscratcher:
         except PriceError:
             price = None
         tvl = total_assets * price / 10 ** self.vault.decimals(block_identifier=block) if price else None
-        return Tvl(total_assets, price, tvl) 
+        return Tvl(total_assets, price, tvl)
 
-        
+
 
 
 class Ygov:


### PR DESCRIPTION
Apy data for backscratcher or special vaults was being returned as camelCase which was not the case for normal vaults which returned all of the attributes in snake_case, which seems to be the default of how the SDK accepts its data from api.yearn.finance ([https://github.com/yearn/yearn-sdk/blob/72ab5137d5cd3c416ed8f92f7939e1bdd33f25c1/src/types/custom/vault.ts#L7](https://github.com/yearn/yearn-sdk/blob/72ab5137d5cd3c416ed8f92f7939e1bdd33f25c1/src/types/custom/vault.ts#L7)).

Just as an example this is what https://api.yearn.finance/v1/chains/1/vaults/all is returning, so there is a mismatch on how we receive that information
<img width="566" alt="Screenshot 2022-01-06 at 14 37 10" src="https://user-images.githubusercontent.com/94012134/148429981-8b98e972-4281-4623-b265-cb89220010ce.png">


This PR should fix that