### PR TITLE
[WEB-1139-193] adds Shapeshift DAO router

### DIFF
--- a/yearn/partners/partners.py
+++ b/yearn/partners/partners.py
@@ -282,4 +282,14 @@ partners = [
             ),
         ],
     ),
+    Partner(
+      name='shapeshiftdao',
+      treasury='0x90a48d5cf7343b08da12e067680b4c6dbfe551be',
+      wrappers=[
+          WildcardWrapper(
+              name='ShapeShift DAO Router',
+              wrapper='0x6a1e73f12018d8e5f966ce794aa2921941feb17e',
+          ),
+      ],
+    ),
 ]

--- a/yearn/partners/partners.py
+++ b/yearn/partners/partners.py
@@ -284,11 +284,11 @@ partners = [
     ),
     Partner(
       name='shapeshiftdao',
-      treasury='0x90a48d5cf7343b08da12e067680b4c6dbfe551be',
+      treasury='0x90A48D5CF7343B08dA12E067680B4C6dbfE551Be',
       wrappers=[
           WildcardWrapper(
               name='ShapeShift DAO Router',
-              wrapper='0x6a1e73f12018d8e5f966ce794aa2921941feb17e',
+              wrapper='0x6a1e73f12018D8e5f966ce794aa2921941feB17E',
           ),
       ],
     ),


### PR DESCRIPTION
Adds the newly deployed Shapeshift DAO Router (0x90a48d5cf7343b08da12e067680b4c6dbfe551be) to the partners list.

Our router is loosely based on the examples provided by Yearn and call's the vault deposit method directly passing the vault tokens to the recipient that is not our contract.

```
vault.deposit(amount, recipient);
```

Is there an easy way to confirm the WildCardWrapper will be functional with this implementation?

Thank you!