### PR TITLE
[WEB-1259-203] fix: correct calculation of discounted rKP3R price

### DIFF
--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -104,7 +104,7 @@ def simple(vault, samples: ApySamples) -> Apy:
             if gauge_reward_token == addresses[chain.id]['rkp3r_rewards']:
                 rKP3R_contract = interface.rKP3R(gauge_reward_token)
                 discount = rKP3R_contract.discount(block_identifier=block)
-                token_price = get_price(addresses[chain.id]['kp3r'], block=block) * discount / 100
+                token_price = get_price(addresses[chain.id]['kp3r'], block=block) * (100 - discount) / 100
             else:
                 token_price = get_price(gauge_reward_token, block=block)
             current_time = time() if block is None else get_block_timestamp(block)


### PR DESCRIPTION
We were calculating rKP3R discount incorrectly. Instead of using the `rKP3R.discount()` as the percentage that rKP3R discounted KP3R redemption price, we should actually be using `100 - rKP3R.discount()`, since the `discount` represents the percentage of the real price that strike price is. At 50%, this didn't matter, so it was correct either way, but on the shift to 90%, it became incorrect. 

In the past, CVX and CRV made up the vast majority of the APR for these vaults, so it wasn't clear that something was wrong. But with KP3R's recent moon and CVX and CRV crashing, the difference became noticeable. 