### PR TITLE
[EXP-30-230] fix: check for reward token

### DIFF
--- a/yearn/apy/curve/rewards.py
+++ b/yearn/apy/curve/rewards.py
@@ -43,6 +43,9 @@ def staking(address: str, pool_price: int, base_asset_price: int, block: Optiona
         # Multiple reward tokens
         queue = 0
         apr = 0
+        if hasattr(staking_rewards, "rewardTokens") == False:
+            print("no reward", staking_rewards.address)
+            return apr
         try:
             token = staking_rewards.rewardTokens(queue, block_identifier=block)
         except ValueError:

--- a/yearn/apy/curve/rewards.py
+++ b/yearn/apy/curve/rewards.py
@@ -43,7 +43,7 @@ def staking(address: str, pool_price: int, base_asset_price: int, block: Optiona
         # Multiple reward tokens
         queue = 0
         apr = 0
-        if hasattr(staking_rewards, "rewardTokens") == False:
+        if not hasattr(staking_rewards, "rewardTokens"):
             print("no reward", staking_rewards.address)
             return apr
         try:


### PR DESCRIPTION
check that the staking rewards contract has a reward token, otherwise set the reward apy to 0