### PR TITLE
[EXP-33-234] refactor: curve oracle and curve v5 support

### DIFF
--- a/tests/prices/test_curve.py
+++ b/tests/prices/test_curve.py
@@ -6,10 +6,10 @@ import pytest
 import requests
 from brownie import ZERO_ADDRESS, chain, multicall, web3
 from tabulate import tabulate
-from yearn.prices import curve
 from yearn.exceptions import PriceError
-from yearn.utils import contract, contract_creation_block
+from yearn.prices import curve
 from yearn.prices.magic import get_price
+from yearn.utils import contract, contract_creation_block
 
 pooldata = json.load(open('tests/fixtures/pooldata.json'))
 
@@ -299,8 +299,8 @@ def test_get_balances_fallback(name):
 @pytest.mark.parametrize('pool', range(len(eur_usd_crypto_pool_tokens)))
 def test_crypto_pool_eur_usd_assets(pool):
     lp_token = eur_usd_crypto_pool_tokens[pool]
-    pool = curve.curve.crypto_swap_registry.get_pool_from_lp_token(lp_token)
-    coins = curve.curve.crypto_swap_registry.get_coins(pool)
+    pool = curve.curve.get_pool(lp_token)
+    coins = curve.curve.get_coins(pool)
     non_zero_coins = list(filter(lambda coin: coin != ZERO_ADDRESS, coins))
     underlying_coin_prices = map(lambda coin: get_price(coin), non_zero_coins)
     summed_coin_prices = sum(underlying_coin_prices)

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -252,7 +252,12 @@ class CurveRegistry(metaclass=Singleton):
             factory = contract(factory)
             # new factory reverts for non-meta pools
             if not hasattr(factory, 'is_meta') or factory.is_meta(pool):
-                coins = factory.get_underlying_coins(pool)
+                if hasattr(factory, 'get_underlying_coins'):
+                    coins = factory.get_underlying_coins(pool)
+                elif hasattr(factory, 'get_coins'):
+                    coins = factory.get_coins(pool)
+                else:
+                    coins = {ZERO_ADDRESS}
             else:
                 coins = factory.get_coins(pool)
         elif registry:

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -14,7 +14,7 @@ from yearn.prices.synthetix import synthetix
 from yearn.prices.uniswap.v1 import uniswap_v1
 from yearn.prices.uniswap.v2 import uniswap_v2
 from yearn.prices.uniswap.v3 import uniswap_v3
-from yearn.prices.curve import curve
+from yearn.prices import curve
 from yearn.prices.yearn import yearn_lens
 from yearn.utils import contract
 
@@ -65,7 +65,8 @@ def find_price(token, block):
         price = yearn_lens.get_price(token, block=block)
         logger.debug("yearn -> %s", price)
 
-    elif chain.id == Network.Fantom:
+    # token-specific overrides
+    if chain.id == Network.Fantom:
         # xcredit
         if token == '0xd9e28749e80D867d5d14217416BFf0e668C10645':
             logger.debug('xcredit -> unwrap')
@@ -75,12 +76,12 @@ def find_price(token, block):
     elif chain.id == Network.Mainnet:
         # no liquid market for yveCRV-DAO -> return CRV token price
         if token == '0xc5bDdf9843308380375a611c18B50Fb9341f502A' and block and block < 11786563:
-            if curve and curve.crv:
-                return get_price(curve.crv, block=block)
+            if curve.curve and curve.curve.crv:
+                return get_price(curve.curve.crv, block=block)
 
     markets = [
         chainlink,
-        curve,
+        curve.curve,
         compound,
         fixed_forex,
         synthetix,

--- a/yearn/sentry.py
+++ b/yearn/sentry.py
@@ -21,6 +21,7 @@ def setup_sentry():
             # of transactions for performance monitoring.
             # We recommend adjusting this value in production.
             traces_sample_rate=1.0,
+            shutdown_timeout=5,
             environment=environment,
             before_send=before_send,
             debug=False,

--- a/yearn/sentry.py
+++ b/yearn/sentry.py
@@ -1,7 +1,7 @@
 import os
 
 from brownie import chain
-from sentry_sdk import Hub, capture_message, init, set_tag
+from sentry_sdk import Hub, capture_message, init, set_tag, utils
 from sentry_sdk.integrations.threading import ThreadingIntegration
 
 from yearn.networks import Network
@@ -20,6 +20,8 @@ def set_custom_tags():
 def setup_sentry():
     sentry_dsn = os.getenv('SENTRY_DSN')
     if sentry_dsn:
+        # give remote backtraces a bit more space
+        utils.MAX_STRING_LENGTH = 8192
         init(
             sentry_dsn,
             # Set traces_sample_rate to 1.0 to capture 100%

--- a/yearn/sentry.py
+++ b/yearn/sentry.py
@@ -12,6 +12,11 @@ def before_send(event, hint):
     # custom event parsing goes here
     return event
 
+def set_custom_tags():
+    set_tag("chain_id", chain.id)
+    set_tag("network_label", Network.label(chain.id))
+
+
 def setup_sentry():
     sentry_dsn = os.getenv('SENTRY_DSN')
     if sentry_dsn:
@@ -30,6 +35,4 @@ def setup_sentry():
                 KeyboardInterrupt, # these can be created when exiting a script with ctrl+c or when an exception is raised in a child thread. Ignore in both cases
             ]
         )
-        set_tag('network',Network(chain.id).name)
-        set_tag('chainid',chain.id)
-
+        set_custom_tags()


### PR DESCRIPTION
* add support for curve v5 factory (fixes #213)
* build lp token to pool mapping on load (`get_lp_token`, `get_token`)
* add cached mappings from registries/factories to pools
* add address provider ids enum for readability
* watch for curve registry updates
* watch for new registries deployed
* remove and generalize cryptoswap registry logic
* deprecate `registry` in favor of `get_registry(pool)`
* change `metapools_by_factory` to cached `factories`
* convert token and pool args to checksum address
* add `read_pool` utility to fetch pool_list/pool_count type registries commonly found in curve
* vastly simplify logic around factory and registry api