### PR TITLE
[EXP-35-236] sentry release tracking + custom tags

### DIFF
--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -17,7 +17,8 @@ x-common-envs: &common-envs
   - EXPLORER:
   - SLEEP_SECONDS:
   - SKIP_WALLET_STATS:
-  - ENV:
+  - SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-development}
+  - SENTRY_RELEASE:
   - SENTRY_DSN:
 
 x-common-historical-envs: &common-historical-envs

--- a/services/ipfs/docker-compose.yml
+++ b/services/ipfs/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - IPFS_NODE_ADDRESS
       - IPFS_NODE_KEY
       - IPFS_NODE_SECRET
-      - ENV
+      - SENTRY_RELEASE
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-development}
       - SENTRY_DSN
     volumes:
       - solidity_compilers:/root/.solcx

--- a/services/tvl/docker-compose.yml
+++ b/services/tvl/docker-compose.yml
@@ -32,7 +32,8 @@ services:
       - PGUSER=postgres
       - PGHOST=postgres
       - PGPASS=yearn
-      - ENV
+      - SENTRY_RELEASE
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-development}
       - SENTRY_DSN
     volumes: 
       - solidity_compilers:/root/.solcx

--- a/yearn/sentry.py
+++ b/yearn/sentry.py
@@ -6,8 +6,6 @@ from sentry_sdk.integrations.threading import ThreadingIntegration
 
 from yearn.networks import Network
 
-environment = os.getenv('ENV', 'DEVELOPMENT')
-
 def before_send(event, hint):
     # custom event parsing goes here
     return event
@@ -29,7 +27,6 @@ def setup_sentry():
             # We recommend adjusting this value in production.
             traces_sample_rate=1.0,
             shutdown_timeout=5,
-            environment=environment,
             before_send=before_send,
             debug=False,
             integrations=[ThreadingIntegration(propagate_hub=True)],

--- a/yearn/sentry.py
+++ b/yearn/sentry.py
@@ -1,6 +1,6 @@
 import os
 
-from brownie import chain
+from brownie import chain, web3
 from sentry_sdk import Hub, capture_message, init, set_tag, utils
 from sentry_sdk.integrations.threading import ThreadingIntegration
 
@@ -12,7 +12,8 @@ def before_send(event, hint):
 
 def set_custom_tags():
     set_tag("chain_id", chain.id)
-    set_tag("network_label", Network.label(chain.id))
+    set_tag("network", Network(chain.id).name)
+    set_tag("web3_client_version", web3.clientVersion)
 
 
 def setup_sentry():


### PR DESCRIPTION
We can activate now sentry release tracking by passing a `SENTRY_RELEASE` env like so:

`export SENTRY_RELEASE=$(git rev-parse --short HEAD)`\
[https://docs.sentry.io/product/releases/](https://docs.sentry.io/product/releases/)

if this is set to a value sentry will show it under the Releases section which can be further filtered by the environment.

The environment (previously `ENV`) has been replaced in favor of sentry's default `SENTRY_ENVIRONMENT`\
[https://docs.sentry.io/platforms/python/configuration/options/#common-options](https://docs.sentry.io/platforms/python/configuration/options/#common-options)

Also changed some custom tags like discussed with Bob.