### PR TITLE
[EXP-40-241] fix: curve registry 0x8F942C20D02bEfc377D41445793068908E2250D0 doesn'…

### DIFF
--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -262,7 +262,11 @@ class CurveRegistry(metaclass=Singleton):
             else:
                 coins = factory.get_coins(pool)
         elif registry:
-            coins = contract(registry).get_underlying_coins(pool)
+            registry = contract(registry)
+            if hasattr(registry, 'get_underlying_coins'):
+                coins = registry.get_underlying_coins(pool)
+            elif hasattr(registry, 'get_coins'):
+                coins = registry.get_coins(pool)
 
         # pool not in registry, not checking for underlying_coins here
         if set(coins) == {ZERO_ADDRESS}:


### PR DESCRIPTION
…t have #get_underlying_coins but has #get_coins.