### PR TITLE
[EXP-45-246] Submit graphite metric when the s3.py script runs successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ generated
 package*.json
 hardhat.config.js
 .idea
+.venv/

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -7,6 +7,7 @@ import shutil
 import json
 import os
 
+
 from datetime import datetime
 from typing import Any, Union
 from time import time
@@ -29,10 +30,14 @@ from yearn.v2.vaults import Vault as VaultV2
 
 from yearn.utils import contract_creation_block, contract, chunks
 
+from yearn.graphite import send_metric
+
 from yearn.exceptions import PriceError
 from yearn.networks import Network
 
 warnings.simplefilter("ignore", BrownieEnvironmentWarning)
+
+METRIC_NAME = "yearn.exporter.apy"
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("yearn.apy")
@@ -131,7 +136,7 @@ def registry_adapter():
 
 def main():
     data = []
-
+    metric_tags = {"chain": chain.id}
     aliases_repo_url = "https://api.github.com/repos/yearn/yearn-assets/git/refs/heads/master"
     aliases_repo = requests.get(aliases_repo_url).json()
     commit = aliases_repo["object"]["sha"]
@@ -199,6 +204,10 @@ def main():
         vault_api_experimental,
         ExtraArgs={'ContentType': "application/json", 'CacheControl': "max-age=1800"},
     )
+
+    # Sent a metric so we can track and alert on if this was successfully generated
+    utc_now = datetime.utcnow()
+    send_metric(f"{METRIC_NAME}.success", 1, utc_now, tags=metric_tags)
 
 
 telegram_users_to_alert = ["@jstashh", "@x48114", "@dudesahn"]

--- a/yearn/graphite.py
+++ b/yearn/graphite.py
@@ -40,14 +40,3 @@ def send_metric(metric_name: str, value: float, time: datetime, tags=None, resol
         logger.error(f"Failed to send metric {metric_name} with value {value}: {result.text}")
 
     logger.debug('%s: %s' % (result.status_code, result.text))
-
-
-# now = datetime.now()
-# metrics = [
-#     ('my.test.metric', 10, 0.23, now - timedelta(seconds=30)),
-#     ('my.test.metric', 10, 1.23, now - timedelta(seconds=20)),
-#     ('my.test.metric', 10, 2.23, now - timedelta(seconds=10)),
-#     ('my.test.metric', 10, 3.23, now),
-# ]
-
-# write_metrics(metrics, GRAFANA_URL, GRAFANA_APIKEY)

--- a/yearn/graphite.py
+++ b/yearn/graphite.py
@@ -1,0 +1,53 @@
+import logging
+import os
+from datetime import datetime
+
+import requests
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("graphite.metrics")
+
+GRAFANA_URL = os.environ.get("GRAFANA_URL")
+GRAFANA_API_KEY = os.environ.get("GRAFANA_API_KEY")
+
+
+def send_metric(metric_name: str, value: float, time: datetime, tags=None, resolution: int = 10):
+    if GRAFANA_URL is None or GRAFANA_API_KEY is None:
+        return
+
+    if not metric_name:
+        raise Exception("Metric name should not be empty")
+
+    metric_tags = []
+    for key, val in tags.items():
+        metric_tags.append(f"{key}={val}")
+
+    headers = {"Authorization": "Bearer %s" % GRAFANA_API_KEY}
+
+    grafana_data = {
+        'name': metric_name,
+        'metric': metric_name,
+        'value': float(value),
+        'interval': int(resolution),
+        'unit': '',
+        'time': int(time.timestamp()),
+        'mtype': 'count',
+        'tags': metric_tags,
+    }
+
+    result = requests.post(GRAFANA_URL, json=[grafana_data], headers=headers)
+    if result.status_code != 200:
+        logger.error(f"Failed to send metric {metric_name} with value {value}: {result.text}")
+
+    logger.debug('%s: %s' % (result.status_code, result.text))
+
+
+# now = datetime.now()
+# metrics = [
+#     ('my.test.metric', 10, 0.23, now - timedelta(seconds=30)),
+#     ('my.test.metric', 10, 1.23, now - timedelta(seconds=20)),
+#     ('my.test.metric', 10, 2.23, now - timedelta(seconds=10)),
+#     ('my.test.metric', 10, 3.23, now),
+# ]
+
+# write_metrics(metrics, GRAFANA_URL, GRAFANA_APIKEY)


### PR DESCRIPTION
# Test Plan

You can test by signing up for a free account here:
https://grafana.com/auth/sign-up/create-user?plcmt=sub-nav

Pass the following environment variables:

* GRAFANA_URL 
* GRAFANA_API_KEY

For example:

```bash
docker build -t yearn-exporter:dev .
docker run -e NETWORK="ftm-main" -e EXPLORER="https://api.ftmscan.com/api" -e WEB3_PROVIDER="<FTM WEB3 PROVIDER>" -e FTMSCAN_TOKEN="<FTMSCAN TOKEN>" -e GRAFANA_API_KEY="<ID>:<PASSWORD>" -e GRAFANA_URL="<YOUR GRAPHITE URL>" yearn-exporter:dev s3
```
