### PR TITLE
[EXP-60-260] fix: use average apy calculations for curve tricrypto vault

### DIFF
--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -30,9 +30,6 @@ PER_MAX_BOOST = 1.0 / MAX_BOOST
 
 
 def simple(vault, samples: ApySamples) -> Apy:
-    if chain.id == Network.Arbitrum:
-        raise ApyError("crv", "not yet implemented")
-        
     lp_token = vault.token.address
 
     pool_address = curve.get_pool(lp_token)

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -215,11 +215,13 @@ class Vault:
 
 
     def _needs_curve_simple(self):
+        # not able to calculate gauge weighting on chains other than mainnet
         curve_simple_excludes = {
             Network.Fantom: [
-                # yvCurve-Tricrypto vault holds a lp_token 0x58e57cA18B7A47112b877E31929798Cd3D703b0f
-                # which doesn't have curve gauge semantics on fantom
                 "0xCbCaF8cB8cbeAFA927ECEE0c5C56560F83E9B7D9"
+            ],
+            Network.Arbitrum: [
+                "0x239e14A19DFF93a17339DCC444f74406C17f8E67"
             ]
         }
         needs_simple = True


### PR DESCRIPTION
Still need to look into whether we can calculate curve apys in the same method we use as on mainnet for other chains, but we could think about just excluding all curve apy calcs for non-mainnet chains and just use average apy calcs