### PR TITLE
[EXP-70-270] fix: full path imports fixes circular import

### DIFF
--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -3,7 +3,7 @@ import logging
 from brownie import chain
 from cachetools.func import ttl_cache
 
-from yearn import special
+from yearn.special import Backscratcher
 from yearn.exceptions import PriceError
 from yearn.networks import Network
 from yearn.prices import balancer as bal
@@ -77,7 +77,7 @@ def find_price(token, block, return_price_during_vault_downtime: bool = False):
 
     elif chain.id == Network.Mainnet:
         # no liquid market for yveCRV-DAO -> return CRV token price
-        if token == special.Backscratcher().vault.address and block and block < 11786563:
+        if token == Backscratcher().vault.address and block and block < 11786563:
             if curve.curve and curve.curve.crv:
                 return get_price(curve.curve.crv, block=block)
 

--- a/yearn/special.py
+++ b/yearn/special.py
@@ -2,7 +2,7 @@ import math
 
 from time import time
 from yearn.common import Tvl
-from yearn.apy.common import Apy, ApyFees, ApyPoints
+from yearn.apy.common import Apy, ApyFees, ApyPoints, ApySamples
 
 import requests
 
@@ -12,7 +12,6 @@ from joblib import Parallel, delayed
 from yearn.prices import magic
 from yearn.prices.curve import curve
 from yearn.utils import Singleton, contract_creation_block, contract
-from yearn.apy import ApySamples
 from yearn.exceptions import PriceError
 
 class YveCRVJar(metaclass = Singleton):
@@ -78,7 +77,7 @@ class Backscratcher(metaclass = Singleton):
         voter = "0xF147b8125d2ef93FB6965Db97D6746952a133934"
         crv_price = magic.get_price("0xD533a949740bb3306d119CC777fa900bA034cd52")
         yvecrv_price = magic.get_price("0xc5bDdf9843308380375a611c18B50Fb9341f502A")
-        
+
         total_vecrv = curve_voting_escrow.totalSupply()
         yearn_vecrv = curve_voting_escrow.balanceOf(voter)
         vault_supply = self.vault.totalSupply()
@@ -106,9 +105,9 @@ class Backscratcher(metaclass = Singleton):
         except PriceError:
             price = None
         tvl = total_assets * price / 10 ** self.vault.decimals(block_identifier=block) if price else None
-        return Tvl(total_assets, price, tvl) 
+        return Tvl(total_assets, price, tvl)
 
-        
+
 
 
 class Ygov(metaclass = Singleton):


### PR DESCRIPTION
Using the full path to import yearn.apy.common objects resolves the circular import error when brownie apy commands are run.