### PR TITLE
[EXP-73-273] fix: record apy inception point from first harvest

### DIFF
--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -28,11 +28,11 @@ def closest(haystack, needle):
 
 
 def simple(vault, samples: ApySamples) -> Apy:
-    harvests = sorted([harvest for strategy in vault.strategies for harvest in strategy.harvests])
+    reports = vault.reports
 
     # we don't want to display APYs when vaults are ramping up
-    if len(harvests) < 2:
-        raise ApyError("v2:harvests", "harvests are < 2")
+    if len(reports) < 2:
+        raise ApyError("v2:reports", "reports are < 2")
     
     # set our time values for simple calcs, closest to a harvest around that time period
     now = closest(harvests, samples.now)
@@ -47,7 +47,7 @@ def simple(vault, samples: ApySamples) -> Apy:
     now_price = price_per_share(block_identifier=now)
 
     # get our inception data
-    inception_block = harvests[0]
+    inception_block = reports[0].block_number
     inception_price = price_per_share(block_identifier=inception_block)
 
     if now_price == inception_price:
@@ -112,21 +112,20 @@ def simple(vault, samples: ApySamples) -> Apy:
 
 
 def average(vault, samples: ApySamples) -> Apy:
-    harvests = sorted([harvest for strategy in vault.strategies for harvest in strategy.harvests])
+    reports = vault.reports
 
     # we don't want to display APYs when vaults are ramping up
-    if len(harvests) < 2:
-        raise ApyError("v2:harvests", "harvests are < 2")
+    if len(reports) < 2:
+        raise ApyError("v2:reports", "reports are < 2")
     
     # set our parameters
     contract = vault.vault
     price_per_share = contract.pricePerShare
-    
     # calculate our current price
     now_price = price_per_share(block_identifier=samples.now)
 
     # get our inception data
-    inception_block = harvests[0]
+    inception_block = reports[0].block_number
     inception_price = price_per_share(block_identifier=inception_block)
 
     if now_price == inception_price:

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -28,11 +28,11 @@ def closest(haystack, needle):
 
 
 def simple(vault, samples: ApySamples) -> Apy:
-    reports = vault.reports
+    harvests = sorted([harvest for strategy in vault.strategies for harvest in strategy.harvests])
 
     # we don't want to display APYs when vaults are ramping up
-    if len(reports) < 2:
-        raise ApyError("v2:reports", "reports are < 2")
+    if len(harvests) < 2:
+        raise ApyError("v2:harvests", "harvests are < 2")
     
     # set our time values for simple calcs, closest to a harvest around that time period
     now = closest(harvests, samples.now)
@@ -47,7 +47,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     now_price = price_per_share(block_identifier=now)
 
     # get our inception data
-    inception_block = reports[0].block_number
+    # the first report is when the vault first allocates funds to farm with
+    inception_block = vault.reports[0].block_number
     inception_price = price_per_share(block_identifier=inception_block)
 
     if now_price == inception_price:
@@ -125,6 +126,7 @@ def average(vault, samples: ApySamples) -> Apy:
     now_price = price_per_share(block_identifier=samples.now)
 
     # get our inception data
+    # the first report is when the vault first allocates funds to farm with
     inception_block = reports[0].block_number
     inception_price = price_per_share(block_identifier=inception_block)
 

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -127,7 +127,7 @@ def average(vault, samples: ApySamples) -> Apy:
 
     # get our inception data
     inception_price = 10 ** contract.decimals()
-    inception_block = harvests[:2][-1]
+    inception_block = harvests[0]
 
     if now_price == inception_price:
         raise ApyError("v2:inception", "no change from inception price")

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -47,8 +47,8 @@ def simple(vault, samples: ApySamples) -> Apy:
     now_price = price_per_share(block_identifier=now)
 
     # get our inception data
-    inception_price = 10 ** contract.decimals()
-    inception_block = harvests[:2][-1]
+    inception_block = harvests[0]
+    inception_price = price_per_share(block_identifier=inception_block)
 
     if now_price == inception_price:
         raise ApyError("v2:inception", "no change from inception price")

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -126,8 +126,8 @@ def average(vault, samples: ApySamples) -> Apy:
     now_price = price_per_share(block_identifier=samples.now)
 
     # get our inception data
-    inception_price = 10 ** contract.decimals()
     inception_block = harvests[0]
+    inception_price = price_per_share(block_identifier=inception_block)
 
     if now_price == inception_price:
         raise ApyError("v2:inception", "no change from inception price")

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -114,6 +114,12 @@ class Vault:
         return list(self._revoked.values())
 
     @property
+    def reports(self):
+        # strategy reports are loaded at the same time as other vault strategy events
+        self.load_strategies()
+        return self._reports
+
+    @property
     def is_endorsed(self):
         if not self.registry:
             return None


### PR DESCRIPTION
There's a problem with yvBoost where there are only two harvests, but the vault is very old, so the inception block is inaccurate.

Instead record the apy inception point as the first harvest - when assets have been deposited by the vault into a strategy and they start earning yield.