### PR TITLE
[EXP-74-274] Fix/eurt vault apy

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -84,19 +84,19 @@ def yvboost():
     calculate_apy("0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a")
 
 
-def ibEUR():
+def ibeur():
     calculate_apy("0x67e019bfbd5a67207755D04467D6A70c0B75bF60")
 
 
-def cvxCRV():
+def cvxcrv():
     calculate_apy("0x4560b99C904aAD03027B5178CCa81584744AC01f")
 
 
-def ibJPY():
+def ibjpy():
     calculate_apy("0x59518884EeBFb03e90a18ADBAAAB770d4666471e")
 
 
-def ibKRW():
+def ibkrw():
     calculate_apy("0x528D50dC9a333f01544177a924893FA1F5b9F748")
 
 

--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -66,7 +66,7 @@ def lusd():
 
 def rai():
     calculate_apy("0x873fB544277FD7b977B196a826459a69E27eA4ea")
-    
+
 
 def tricrypto():
     calculate_apy("0x3D980E50508CFd41a13837A60149927a11c037")
@@ -94,7 +94,7 @@ def cvxCRV():
 
 def ibJPY():
     calculate_apy("0x59518884EeBFb03e90a18ADBAAAB770d4666471e")
-    
+
 
 def ibKRW():
     calculate_apy("0x528D50dC9a333f01544177a924893FA1F5b9F748")
@@ -102,27 +102,19 @@ def ibKRW():
 
 def yfi():
     calculate_apy("0xdb25cA703181E7484a155DD612b06f57E12Be5F0")
-    
+
 
 def sushi():
     calculate_apy("0x6d765CbE5bC922694afE112C140b8878b9FB0390")
-    
 
-def ibeur():
-    calculate_apy("0x67e019bfbd5a67207755D04467D6A70c0B75bF60")
-    
 
 def ibgbp():
     calculate_apy("0x595a68a8c9D5C230001848B69b1947ee2A607164")
-    
 
-def ibkrw():
-    calculate_apy("0x528D50dC9a333f01544177a924893FA1F5b9F748")
-    
 
 def dai():
     calculate_apy("0xdA816459F1AB5631232FE5e97a05BBBb94970c95")
-    
+
 
 def old_dai():
     calculate_apy("0x19D3364A399d251E894aC732651be8B0E4e85001")

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -49,7 +49,7 @@ def simple(vault, samples: ApySamples) -> Apy:
         controller = curve.gauge_controller
 
     block = samples.now
-    gauge_weight = controller.gauge_relative_weight.call(gauge_address, block_identifier=block) 
+    gauge_weight = controller.gauge_relative_weight.call(gauge_address, block_identifier=block)
     gauge_working_supply = gauge.working_supply(block_identifier=block)
     if gauge_working_supply == 0:
         raise ApyError("crv", "gauge working supply is zero")
@@ -166,7 +166,7 @@ def simple(vault, samples: ApySamples) -> Apy:
             cvx_boost = cvx_working_balance / (PER_MAX_BOOST * cvx_gauge_balance) or 1
         else:
             cvx_boost = MAX_BOOST
-        
+
         cvx_booster = contract(addresses[chain.id]['convex_booster'])
         cvx_lock_incentive = cvx_booster.lockIncentive(block_identifier=block)
         cvx_staker_incentive = cvx_booster.stakerIncentive(block_identifier=block)
@@ -191,7 +191,7 @@ def simple(vault, samples: ApySamples) -> Apy:
 
         cvx_apr = ((1 - cvx_fee) * cvx_boost * base_apr) * (1 + cvx_printed_as_crv) + reward_apr
         cvx_apr_minus_keep_crv = ((1 - cvx_fee) * cvx_boost * base_apr) * ((1 - cvx_keep_crv) + cvx_printed_as_crv)
-        
+
         crv_debt_ratio = vault.vault.strategies(crv_strategy)[2] / 1e4
         cvx_debt_ratio = vault.vault.strategies(cvx_strategy)[2] / 1e4
     else:

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -225,13 +225,11 @@ class CurveRegistry(metaclass=Singleton):
         pool = to_address(pool)
         factory = self.get_factory(pool)
         registry = self.get_registry(pool)
-        if (
-            factory and
-            hasattr((contract_factory := contract(factory)), 'get_gauge') and
-            (gauge := contract_factory.get_gauge(pool)) != ZERO_ADDRESS
-        ):
-            return gauge
-        elif registry:
+        if factory and hasattr(contract(factory), 'get_gauge'):
+            gauge = contract(factory).get_gauge(pool)
+            if gauge != ZERO_ADDRESS:
+                return gauge
+        if registry:
             gauges, _ = contract(registry).get_gauges(pool)
             if gauges[0] != ZERO_ADDRESS:
                 return gauges[0]

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -137,7 +137,7 @@ class CurveRegistry(metaclass=Singleton):
                     self.token_to_pool[lp_token] = event['pool']
                 elif event.name == 'PoolRemoved':
                     self.registries[event.address].discard(event['pool'])
-                    
+
             # load metapool and curve v5 factories
             self.load_factories()
 
@@ -225,12 +225,14 @@ class CurveRegistry(metaclass=Singleton):
         pool = to_address(pool)
         factory = self.get_factory(pool)
         registry = self.get_registry(pool)
-        if factory and hasattr(contract(factory), 'get_gauge'):
-            gauge = contract(factory).get_gauge(pool)
-            if gauge != ZERO_ADDRESS:
-                return gauge
+        if (
+            factory and
+            hasattr((contract_factory := contract(factory)), 'get_gauge') and
+            (gauge := contract_factory.get_gauge(pool)) != ZERO_ADDRESS
+        ):
+            return gauge
         elif registry:
-            gauges, types = contract(registry).get_gauges(pool)
+            gauges, _ = contract(registry).get_gauges(pool)
             if gauges[0] != ZERO_ADDRESS:
                 return gauges[0]
 


### PR DESCRIPTION
In calculating vault apy, the liquidity gauge contract is required.  Generally this address is found in either the `factory` or `registry`, whichever has a `get_gauge` method.  `Eurt`, is unique in that it has both a `factory` and a `registry` with the `get_gauge` method.  The current implementation will return `contract(factory).get_gauge(pool)` if it's not the `ZERO_ADDRESS` or None.  The gauge address for `Eurt` is found in the `registry` contract but it is never reached b/c the if statement is taken as opposed to the elif shown below.  If we add the additional constraint that `contract(factory).get_gauge(pool)` must also be not the `ZERO_ADDRESS` we can accomodate the `Eurt` edge case.

Additional changes: deleted unnecessary whitespace (editor setting) and removed duplicate apy function calls.