### PR TITLE
[EXP-83-283] fix: use weekly apys for fantom

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -124,3 +124,6 @@ def eurs_usdc():
 
 def crv_eth():
     calculate_apy("0x6A5468752f8DB94134B6508dAbAC54D3b45efCE6")
+
+def spooky():
+    calculate_apy("0x0fBbf9848D969776a5Eb842EdAfAf29ef4467698")

--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -124,6 +124,3 @@ def eurs_usdc():
 
 def crv_eth():
     calculate_apy("0x6A5468752f8DB94134B6508dAbAC54D3b45efCE6")
-
-def spooky():
-    calculate_apy("0x0fBbf9848D969776a5Eb842EdAfAf29ef4467698")

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -77,14 +77,14 @@ def simple(vault, samples: ApySamples) -> Apy:
     inception_apy = calculate_roi(now_point, inception_point)
 
     # use the first non-zero apy, ordered by precedence
-    # For Fantom, prioritize the weekly apy over the monthly. 
+    # For Fantom, prioritize the weekly APY over the monthly. 
     # The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, 
     # where infrequent harvests mean showing the weekly APY results in misleading spikes
     if chain.id == Network.Fantom:
         apys = [week_ago_apy, month_ago_apy]
     else:
         apys = [month_ago_apy, week_ago_apy]
-        
+
     net_apy = next((value for value in apys if value != 0), 0)
 
     # for performance fee, half comes from strategy (strategist share) and half from the vault (treasury share)
@@ -167,7 +167,7 @@ def average(vault, samples: ApySamples) -> Apy:
     # we should look at a vault's harvests, age, etc to determine whether to show new APY or not
 
     # use the first non-zero apy, ordered by precedence
-    # For Fantom, prioritize the weekly apy over the monthly. 
+    # For Fantom, prioritize the weekly APY over the monthly. 
     # The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, 
     # where infrequent harvests mean showing the weekly APY results in misleading spikes
     if chain.id == Network.Fantom:

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -81,9 +81,9 @@ def simple(vault, samples: ApySamples) -> Apy:
     # The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, 
     # where infrequent harvests mean showing the weekly APY results in misleading spikes
     if chain.id == Network.Fantom:
-        apys = [week_ago_apy, month_ago_apy]
+        apys = [week_ago_apy, month_ago_apy, inception_apy]
     else:
-        apys = [month_ago_apy, week_ago_apy]
+        apys = [month_ago_apy, week_ago_apy, inception_apy]
 
     net_apy = next((value for value in apys if value != 0), 0)
 

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -1,5 +1,7 @@
 from bisect import bisect_left
 from datetime import datetime, timedelta
+from brownie import chain
+from yearn.networks import Network
 
 from semantic_version.base import Version
 
@@ -75,7 +77,14 @@ def simple(vault, samples: ApySamples) -> Apy:
     inception_apy = calculate_roi(now_point, inception_point)
 
     # use the first non-zero apy, ordered by precedence
-    apys = [month_ago_apy, week_ago_apy, inception_apy]
+    # For Fantom, prioritize the weekly apy over the monthly. 
+    # The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, 
+    # where infrequent harvests mean showing the weekly APY results in misleading spikes
+    if chain.id == Network.Fantom:
+        apys = [week_ago_apy, month_ago_apy]
+    else:
+        apys = [month_ago_apy, week_ago_apy]
+        
     net_apy = next((value for value in apys if value != 0), 0)
 
     # for performance fee, half comes from strategy (strategist share) and half from the vault (treasury share)
@@ -158,7 +167,14 @@ def average(vault, samples: ApySamples) -> Apy:
     # we should look at a vault's harvests, age, etc to determine whether to show new APY or not
 
     # use the first non-zero apy, ordered by precedence
-    apys = [month_ago_apy, week_ago_apy]
+    # For Fantom, prioritize the weekly apy over the monthly. 
+    # The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, 
+    # where infrequent harvests mean showing the weekly APY results in misleading spikes
+    if chain.id == Network.Fantom:
+        apys = [week_ago_apy, month_ago_apy]
+    else:
+        apys = [month_ago_apy, week_ago_apy]
+
     two_months_ago = datetime.now() - timedelta(days=60)
     if contract.activation() > two_months_ago.timestamp():
         # if the vault was activated less than two months ago then it's ok to use


### PR DESCRIPTION
For Fantom, prioritize the weekly apy over the monthly. The APYs on Fantom vary quickly and harvests are more frequent than on mainnet, where infrequent harvests mean showing the weekly APY results in misleading spikes