### PR TITLE
[EXP-84-284] fix: more convex fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pandas>=1.3.0
 pony>=0.6.7
 sqlalchemy>=1.4.26
 sentry-sdk>=1.5.1
+pytest-bdd>=5.0.0

--- a/services/dashboard/docker-compose.test.yml
+++ b/services/dashboard/docker-compose.test.yml
@@ -12,16 +12,20 @@ networks:
 services:
   test:
     image: yearn-exporter
-    entrypoint: pytest tests
+    build: .
+    entrypoint: /app/yearn-exporter/tests.sh
     environment:
       - WEB3_PROVIDER
       - ETHERSCAN_TOKEN
       - EXPLORER
       - SLEEP_SECONDS
+      - TEST_CMD
     volumes:
+      - .:/tests
       - solidity_compilers:/root/.solcx
       - vyper_compilers:/root/.vvm
       - brownie:/root/.brownie
       - cache:/app/yearn-exporter/cache
     networks:
       - yearn-exporter
+    tty: true

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /tests
+TEST_CMD=${TEST_CMD:-pytest}
+$TEST_CMD

--- a/tests/apy/curve_simple_apy.feature
+++ b/tests/apy/curve_simple_apy.feature
@@ -1,0 +1,12 @@
+Feature: Curve APY calculation
+    Scenario: Calculating curve simple
+        Given I set the date to '2022-04-06'
+        And I calculate the APY for the vault <address>
+        Then the type should be <type>
+        And the gross_apr should be <gross_apr>
+        And the net_apy should be <net_apy>
+
+        Examples:
+        | address                                     | type  | gross_apr           | net_apy             |
+        | 0xdCD90C7f6324cfa40d7169ef80b12031770B4325  | crv   | 0.05737093451761255 | 0.050058512767167204|
+        | 0x27b7b1ad7288079A66d12350c828D3C00A6F07d7  | crv   | 0.11176129880725783 | 0.0691230850636729  |

--- a/tests/apy/test_apy.py
+++ b/tests/apy/test_apy.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+import pytest
+from pytest_bdd import scenario, given, then, parsers
+from yearn.apy.curve.simple import simple
+from yearn.apy.common import get_samples
+from yearn.v2.vaults import Vault as VaultV2
+
+@scenario("curve_simple_apy.feature", "Calculating curve simple")
+def test_curve_simple_apy():
+    pass
+
+@given(parsers.parse("I set the date to '{date}'"), target_fixture="apy_samples")
+def given_set_date(date):
+    now_time = datetime.strptime(date, "%Y-%m-%d")
+    return get_samples(now_time)
+
+@given(parsers.parse("I calculate the APY for the vault {address}"), target_fixture="apy_result")
+def given_start_calculation(apy_samples, address):
+    vault = VaultV2.from_address(address)
+    return simple(vault, apy_samples)
+
+@then(parsers.parse("the type should be {type}"))
+def should_match_type(apy_result, type):
+    assert apy_result.type == type
+
+@then(parsers.parse("the gross_apr should be {gross_apr:f}"))
+def should_match_gross_apr(apy_result, gross_apr):
+    assert pytest.approx(apy_result.gross_apr, rel=1e-2) == gross_apr
+
+@then(parsers.parse("the net_apy should be {net_apy:f}"))
+def should_match_net_apy(apy_result, net_apy):
+    assert pytest.approx(apy_result.net_apy, rel=1e-2) == net_apy

--- a/tests/apy/test_convex.py
+++ b/tests/apy/test_convex.py
@@ -1,0 +1,35 @@
+import pytest
+from unittest.mock import MagicMock
+from yearn.apy.curve.simple import _ConvexVault
+from yearn.v2.vaults import Vault as VaultV2
+
+@pytest.fixture
+def v2_vault():
+    return MagicMock(spec=VaultV2)
+
+@pytest.fixture
+def convex_strategy():
+    strategy = MagicMock()
+    strategy.name = "convexTestStrat"
+    return strategy
+
+@pytest.fixture
+def non_convex_strategy():
+    strategy = MagicMock()
+    strategy.name = "yetAnotherTestStrat"
+    return strategy
+
+def test_is_convex_vault(v2_vault, convex_strategy):
+    v2_vault.strategies = [convex_strategy]
+    assert _ConvexVault.is_convex_vault(v2_vault) == True
+
+def test_is_not_convex_vault(v2_vault, non_convex_strategy):
+    v2_vault.strategies = [non_convex_strategy]
+    assert _ConvexVault.is_convex_vault(v2_vault) == False
+
+def test_is_convex_strategy(convex_strategy):
+    assert _ConvexVault.is_convex_strategy(convex_strategy) == True
+
+def test_is_non_convex_strategy(non_convex_strategy):
+    assert _ConvexVault.is_convex_strategy(non_convex_strategy) == False
+

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -314,7 +314,7 @@ class _ConvexVault:
         try:
             pid = cvx_strategy.pid()
         except AttributeError:
-            # Curve hBTC strategy uses id rather than pid - 0x7Ed0d52C5944C7BF92feDC87FEC49D474ee133ce
+            # Convex hBTC strategy uses id rather than pid - 0x7Ed0d52C5944C7BF92feDC87FEC49D474ee133ce
             pid = cvx_strategy.id()
         rewards_contract = contract(cvx_booster.poolInfo(pid)["crvRewards"])
         rewards_length = rewards_contract.extraRewardsLength()

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -362,10 +362,10 @@ class _ConvexVault:
 def _get_reward_token_price(reward_token, block=None):
     # if the reward token is rKP3R we need to calculate it's price in 
     # terms of KP3R after the discount
-    addresses = addresses[chain.id]
-    if reward_token == addresses['rkp3r_rewards']:
+    contract_addresses = addresses[chain.id]
+    if reward_token == contract_addresses['rkp3r_rewards']:
         rKP3R_contract = interface.rKP3R(reward_token)
         discount = rKP3R_contract.discount(block_identifier=block)
-        return magic.get_price(addresses['kp3r'], block=block) * (100 - discount) / 100
+        return magic.get_price(contract_addresses['kp3r'], block=block) * (100 - discount) / 100
     else:
         return magic.get_price(reward_token, block=block)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -314,6 +314,7 @@ class _ConvexVault:
         try:
             pid = cvx_strategy.pid()
         except AttributeError:
+            # Curve hBTC strategy uses id rather than pid - 0x7Ed0d52C5944C7BF92feDC87FEC49D474ee133ce
             pid = cvx_strategy.id()
         rewards_contract = contract(cvx_booster.poolInfo(pid)["crvRewards"])
         rewards_length = rewards_contract.extraRewardsLength()

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -315,12 +315,13 @@ class _ConvexVault:
         """The cumulative apr of all extra tokens that are emitted by depositing 
         to Convex, assuming that they will be sold for profit.
         """
-        # pull data from convex's virtual rewards contracts to get bonus rewards
-        try:
-            pid = cvx_strategy.pid()
-        except AttributeError:
+        if hasattr(cvx_strategy, "id"):
             # Convex hBTC strategy uses id rather than pid - 0x7Ed0d52C5944C7BF92feDC87FEC49D474ee133ce
             pid = cvx_strategy.id()
+        else:
+            pid = cvx_strategy.pid()
+            
+        # pull data from convex's virtual rewards contracts to get bonus rewards
         rewards_contract = contract(cvx_booster.poolInfo(pid)["crvRewards"])
         rewards_length = rewards_contract.extraRewardsLength()
         current_time = time() if block is None else get_block_timestamp(block)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -311,7 +311,10 @@ class _ConvexVault:
         to Convex, assuming that they will be sold for profit.
         """
         # pull data from convex's virtual rewards contracts to get bonus rewards
-        pid = cvx_strategy.pid()
+        try:
+            pid = cvx_strategy.pid()
+        except AttributeError:
+            pid = cvx_strategy.id()
         rewards_contract = contract(cvx_booster.poolInfo(pid)["crvRewards"])
         rewards_length = rewards_contract.extraRewardsLength()
         current_time = time() if block is None else get_block_timestamp(block)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -43,7 +43,7 @@ PER_MAX_BOOST = 1.0 / MAX_BOOST
 def simple(vault, samples: ApySamples) -> Apy:
     if chain.id != Network.Mainnet:
         raise ApyError("crv", "chain not supported")
-        
+
     lp_token = vault.token.address
 
     pool_address = curve.get_pool(lp_token)
@@ -362,9 +362,10 @@ class _ConvexVault:
 def _get_reward_token_price(reward_token, block=None):
     # if the reward token is rKP3R we need to calculate it's price in 
     # terms of KP3R after the discount
-    if reward_token == addresses[chain.id]['rkp3r_rewards']:
+    addresses = addresses[chain.id]
+    if reward_token == addresses['rkp3r_rewards']:
         rKP3R_contract = interface.rKP3R(reward_token)
         discount = rKP3R_contract.discount(block_identifier=block)
-        return magic.get_price(addresses[chain.id]['kp3r'], block=block) * (100 - discount) / 100
+        return magic.get_price(addresses['kp3r'], block=block) * (100 - discount) / 100
     else:
         return magic.get_price(reward_token, block=block)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -41,6 +41,9 @@ PER_MAX_BOOST = 1.0 / MAX_BOOST
 
 
 def simple(vault, samples: ApySamples) -> Apy:
+    if chain.id != Network.Mainnet:
+        raise ApyError("crv", "chain not supported")
+        
     lp_token = vault.token.address
 
     pool_address = curve.get_pool(lp_token)


### PR DESCRIPTION
* Ensure strategies are in the correct order - curve first, then convex
* Correct price calculation for `rKP3R`
* Handle some strategies using `id` instead of `pid`
* Handle some strategies using `localKeepCRV` rather than `KeepCRV`