### PR TITLE
[EXP-85-285] fix: send block as hex to the batched eth_call because go-opera does …

### DIFF
--- a/yearn/multicall2.py
+++ b/yearn/multicall2.py
@@ -107,7 +107,7 @@ def batch_call(calls):
                 'method': 'eth_call',
                 'params': [
                     {'to': str(contract), 'data': fn.encode_input(*fn_inputs)},
-                    block,
+                    hex(block),
                 ],
             }
         )


### PR DESCRIPTION
…not support numerical blocks.