### PR TITLE
[EXP-103-303] fix: remove assumption that strategy performance fee is equal to vaults

### DIFF
--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -151,7 +151,7 @@ def simple(vault, samples: ApySamples) -> Apy:
             crv_keep_crv = vault.strategies[0].strategy.keepCrvPercent(block_identifier=block) / 1e4
         else:
             crv_keep_crv = 0
-        performance = (vault_contract.performanceFee(block_identifier=block) * 2) / 1e4 if hasattr(vault_contract, "performanceFee") else 0
+        performance = vault_contract.performanceFee(block_identifier=block) / 1e4 if hasattr(vault_contract, "performanceFee") else 0
         management = vault_contract.managementFee(block_identifier=block) / 1e4 if hasattr(vault_contract, "managementFee") else 0
     else:
         strategy = vault.strategy


### PR DESCRIPTION
Before the code assumed that the performance fee of the strategy was equal to the performance fee from the vault, so total performance fee = 2 \* vault performance fee. This led to incorrectly low apys.

However with the recent changes to all performance fees being handled by the vault, and not the strategy, this assumption is no longer valid.