### PR TITLE
[EXP-105-305] fix: exclude mim-3pool fantom vault from apy calculations

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -124,3 +124,6 @@ def eurs_usdc():
 
 def crv_eth():
     calculate_apy("0x6A5468752f8DB94134B6508dAbAC54D3b45efCE6")
+
+def mim_crv():
+    calculate_apy("0xA97E7dA01C7047D6a65f894c99bE8c832227a8BC")

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -230,7 +230,8 @@ class Vault:
         # not able to calculate gauge weighting on chains other than mainnet
         curve_simple_excludes = {
             Network.Fantom: [
-                "0xCbCaF8cB8cbeAFA927ECEE0c5C56560F83E9B7D9"
+                "0xCbCaF8cB8cbeAFA927ECEE0c5C56560F83E9B7D9",
+                "0xA97E7dA01C7047D6a65f894c99bE8c832227a8BC"
             ],
             Network.Arbitrum: [
                 "0x239e14A19DFF93a17339DCC444f74406C17f8E67"


### PR DESCRIPTION
It's a curve vault but curve vault apy calculations are not supported on anything other than mainnet, fallback to defaults pps apy calculations