### PR TITLE
[EXP-109-309] fix: 0xB01E8419d842beebf1b70A7b5f7142abbaf7159D (COVER) on ftm throws…

### DIFF
--- a/yearn/prices/band.py
+++ b/yearn/prices/band.py
@@ -5,6 +5,7 @@ from cachetools.func import ttl_cache
 from yearn.utils import Singleton
 from yearn.networks import Network
 from yearn.exceptions import UnsupportedNetwork
+from brownie.exceptions import VirtualMachineError
 from yearn.utils import contract
 
 
@@ -52,6 +53,8 @@ class Band(metaclass=Singleton):
         try:
             return self.oracle.getReferenceData(asset_symbol, 'USDC', block_identifier=block)[0] / 1e18
         except ValueError:
+            return None
+        except VirtualMachineError:
             return None
 
 


### PR DESCRIPTION
… a VM error with the band oracle for newer blocks.