### PR TITLE
[EXP-111-311] chore: bump eth_retry version

### DIFF
--- a/.github/workflows/tests._fullsuite.yaml
+++ b/.github/workflows/tests._fullsuite.yaml
@@ -7,6 +7,7 @@ on:
       - '**.py'
       - '**/pytest.yaml'
       - '**/tests._fullsuite.yaml'
+      - '**/requirements.txt'
 
 jobs:
   test_full_suite:

--- a/.github/workflows/tests.partners.on_pull_req.yaml
+++ b/.github/workflows/tests.partners.on_pull_req.yaml
@@ -11,6 +11,7 @@ on:
       - '**/contracts.py'
       - '**/events.py'
       - '**/middleware.py'
+      - '**/requirements.txt'
 
 jobs:
   test_partners:

--- a/.github/workflows/tests.partners.on_push.yaml
+++ b/.github/workflows/tests.partners.on_push.yaml
@@ -9,6 +9,7 @@ on:
       - '**/contracts.py'
       - '**/events.py'
       - '**/middleware.py'
+      - '**/requirements.txt'
 
 jobs:
   test_partners:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pony>=0.6.7
 sqlalchemy>=1.4.26
 sentry-sdk>=1.5.1
 pytest-bdd>=5.0.0
-eth_retry>=0.0.3
+eth_retry>=0.0.4


### PR DESCRIPTION
eth_retry was extended to retry on requests.exceptions.ConnectionError in addition to the regular ConnectionError. This is necessary per the failed tests on minor-fixes branch and will eliminate similar failures in the future.