### PR TITLE
[EXP-112-312] fix: correct negative cvx vault net apy

### DIFF
--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -12,7 +12,6 @@ from yearn.v1.registry import Registry as RegistryV1
 from yearn.v2.registry import Registry as RegistryV2
 from yearn.v2.strategies import Strategy as StrategyV2
 from yearn.v2.vaults import Vault as VaultV2
-from yearn.prices.magic import get_price
 
 sentry_sdk.set_tag('script','apy')
 
@@ -128,8 +127,3 @@ def crv_eth():
 
 def mim_crv():
     calculate_apy("0xA97E7dA01C7047D6a65f894c99bE8c832227a8BC")
-
-def reth():
-    calculate_apy("0x5c0A86A32c129538D62C106Eb8115a8b02358d57")
-    # price = get_price("0x447Ddd4960d9fdBF6af9a790560d0AF76795CB08")
-    # print(price)

--- a/scripts/apy.py
+++ b/scripts/apy.py
@@ -12,6 +12,7 @@ from yearn.v1.registry import Registry as RegistryV1
 from yearn.v2.registry import Registry as RegistryV2
 from yearn.v2.strategies import Strategy as StrategyV2
 from yearn.v2.vaults import Vault as VaultV2
+from yearn.prices.magic import get_price
 
 sentry_sdk.set_tag('script','apy')
 
@@ -127,3 +128,8 @@ def crv_eth():
 
 def mim_crv():
     calculate_apy("0xA97E7dA01C7047D6a65f894c99bE8c832227a8BC")
+
+def reth():
+    calculate_apy("0x5c0A86A32c129538D62C106Eb8115a8b02358d57")
+    # price = get_price("0x447Ddd4960d9fdBF6af9a790560d0AF76795CB08")
+    # print(price)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -256,6 +256,10 @@ class _ConvexVault:
         cvx_net_farmed_apy = (1 + (cvx_net_apr / COMPOUNDING)) ** COMPOUNDING - 1
         cvx_net_apy = ((1 + cvx_net_farmed_apy) * (1 + pool_apy)) - 1
 
+        # 0.3.5+ should never be < 0% because of management
+        if cvx_net_apy < 0 and Version(self.vault.api_version) >= Version("0.3.5"): 
+            cvx_net_apy = 0
+
         fees = ApyFees(performance=performance_fee, management=management_fee, cvx_keep_crv=apy_data.cvx_keep_crv)
         return Apy("convex", gross_apr, cvx_net_apy, fees)
 


### PR DESCRIPTION
net apy can not be negative for vaults with version > 0.3.5, which all convex vaults should be anyway