### PR TITLE
[EXP-114-314] fix: use specific vmagent docker image which is still compatible with…

### DIFF
--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -383,7 +383,7 @@ services:
       - postgres
 
   vmagent:
-    image: victoriametrics/vmagent
+    image: victoriametrics/vmagent:heads-public-single-node-0-g52eb9c99e
     volumes:
       - ./prometheus/:/etc/prometheus/
     command:


### PR DESCRIPTION
… the prometheus.yml scraper config.