### PR TITLE
[EXP-116-316] fix: check for division by zero when calculating gross apr

### DIFF
--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -207,11 +207,11 @@ def average(vault, samples: ApySamples) -> Apy:
     apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding if net_apy > 0 else net_apy
 
     # calculate our pre-fee APR
-    performance_fee_denomiator = 1 - performance 
-    if performance_fee_denomiator == 0:
+    performance_fee_denominator = 1 - performance 
+    if performance_fee_denominator == 0:
         gross_apr = 0
     else: 
-        gross_apr = apr_after_fees / performance_fee_denomiator + management
+        gross_apr = apr_after_fees / performance_fee_denominator + management
 
     # 0.3.5+ should never be < 0% because of management
     if net_apy < 0 and Version(vault.api_version) >= Version("0.3.5"):

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -207,11 +207,11 @@ def average(vault, samples: ApySamples) -> Apy:
     apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding if net_apy > 0 else net_apy
 
     # calculate our pre-fee APR
-    gross_apr_denomimator = 1 - performance + management
-    if gross_apr_denomimator == 0:
+    performance_fee_denomiator = 1 - performance 
+    if performance_fee_denomiator == 0:
         gross_apr = 0
     else: 
-        gross_apr = apr_after_fees / gross_apr_denomimator
+        gross_apr = apr_after_fees / performance_fee_denomiator + management
 
     # 0.3.5+ should never be < 0% because of management
     if net_apy < 0 and Version(vault.api_version) >= Version("0.3.5"):

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -207,7 +207,11 @@ def average(vault, samples: ApySamples) -> Apy:
     apr_after_fees = compounding * ((net_apy + 1) ** (1 / compounding)) - compounding if net_apy > 0 else net_apy
 
     # calculate our pre-fee APR
-    gross_apr = apr_after_fees / (1 - performance) + management
+    gross_apr_denomimator = 1 - performance + management
+    if gross_apr_denomimator == 0:
+        gross_apr = 0
+    else: 
+        gross_apr = apr_after_fees / gross_apr_denomimator
 
     # 0.3.5+ should never be < 0% because of management
     if net_apy < 0 and Version(vault.api_version) >= Version("0.3.5"):

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -209,7 +209,7 @@ def average(vault, samples: ApySamples) -> Apy:
     # calculate our pre-fee APR
     performance_fee_denominator = 1 - performance 
     if performance_fee_denominator == 0:
-        gross_apr = 0
+        gross_apr = apr_after_fees + management
     else: 
         gross_apr = apr_after_fees / performance_fee_denominator + management
 


### PR DESCRIPTION
Was getting a division by 0 error for this vault - https://etherscan.io/address/0xD4108Bb1185A5c30eA3f4264Fd7783473018Ce17, which has a total performance fee of 100%, and 0% management fee