### PR TITLE
[EXP-117-317] fix: exclude curve usdk vault from curve apy calculations

### DIFF
--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -229,6 +229,9 @@ class Vault:
     def _needs_curve_simple(self):
         # not able to calculate gauge weighting on chains other than mainnet
         curve_simple_excludes = {
+            Network.Mainnet: [
+                "0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E"
+            ],
             Network.Fantom: [
                 "0xCbCaF8cB8cbeAFA927ECEE0c5C56560F83E9B7D9",
                 "0xA97E7dA01C7047D6a65f894c99bE8c832227a8BC"


### PR DESCRIPTION
net apy is 1.2048184716443852e+21 which is correct when cross referencing with convex's apr, however something with curve's pool apr must be incorrect. This PR defaults back to pps apy calculations, since there aren't any harvests an apy value will not be provided. The vault has never been deposited into anyway since it was deployed about a year ago so this data isn't needed anyway.

[https://etherscan.io/address/0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E](https://etherscan.io/address/0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E)

<img width="684" alt="Screenshot 2022-05-16 at 19 53 23" src="https://user-images.githubusercontent.com/19509999/168662391-060bc47a-fe4b-4d30-97aa-0aae0678b350.png">

