### PR TITLE
balancer v2 pools and some more price discovery fixes

### DIFF
--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -20,6 +20,7 @@ x-common-envs: &common-envs
   - SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-development}
   - SENTRY_RELEASE:
   - SENTRY_DSN:
+  - LOG_LEVEL:
 
 x-common-historical-envs: &common-historical-envs
   - POOL_SIZE:

--- a/yearn/logs.py
+++ b/yearn/logs.py
@@ -1,11 +1,12 @@
 import logging
 import warnings
+import os
 from brownie.exceptions import BrownieEnvironmentWarning
 
 
 def setup_logging():
     logging.basicConfig(
-        level=logging.INFO,
+        level=os.getenv("LOG_LEVEL", "INFO"),
         format="%(levelname)s %(name)s:%(lineno)d %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )

--- a/yearn/prices/balancer/balancer.py
+++ b/yearn/prices/balancer/balancer.py
@@ -16,11 +16,6 @@ class BalancerSelector:
             version: balancer for version, balancer in BALANCERS.items() if balancer
         }
 
-
-    def has_balancers(self) -> bool:
-        return len(self.balancers) > 0
-
-
     def get_balancer_for_pool(self, address: Address) -> Optional[Union[BalancerV1, BalancerV2]]:
         for b in BALANCERS.values():
             if b.is_balancer_pool(address):

--- a/yearn/prices/balancer/balancer.py
+++ b/yearn/prices/balancer/balancer.py
@@ -17,7 +17,7 @@ class BalancerSelector:
         }
 
 
-    def has_balancers() -> bool:
+    def has_balancers(self) -> bool:
         return len(self.balancers) > 0
 
 

--- a/yearn/prices/balancer/balancer.py
+++ b/yearn/prices/balancer/balancer.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Optional, Union
+from yearn.prices.balancer.v1 import BalancerV1, balancer_v1
+from yearn.prices.balancer.v2 import BalancerV2, balancer_v2
+from yearn.typing import Address
+
+logger = logging.getLogger(__name__)
+
+BALANCERS = {
+  "v1": balancer_v1,
+  "v2": balancer_v2
+}
+class BalancerSelector:
+    def __init__(self) -> None:
+        self.balancers = {
+            version: balancer for version, balancer in BALANCERS.items() if balancer
+        }
+
+
+    def has_balancers() -> bool:
+        return len(self.balancers) > 0
+
+
+    def get_balancer_for_pool(self, address: Address) -> Optional[Union[BalancerV1, BalancerV2]]:
+        for b in BALANCERS.values():
+            if b.is_balancer_pool(address):
+                return b
+
+        return None
+
+selector = BalancerSelector()

--- a/yearn/prices/balancer/balancer.py
+++ b/yearn/prices/balancer/balancer.py
@@ -18,7 +18,7 @@ class BalancerSelector:
 
     def get_balancer_for_pool(self, address: Address) -> Optional[Union[BalancerV1, BalancerV2]]:
         for b in BALANCERS.values():
-            if b.is_balancer_pool(address):
+            if b and b.is_balancer_pool(address):
                 return b
 
         return None

--- a/yearn/prices/balancer/v1.py
+++ b/yearn/prices/balancer/v1.py
@@ -20,7 +20,7 @@ def is_balancer_pool_cached(address: Address) -> bool:
         return True
     return False
 
-class Balancer(metaclass=Singleton):
+class BalancerV1(metaclass=Singleton):
     def __init__(self) -> None:
         if chain.id not in networks:
             raise UnsupportedNetwork('Balancer is not supported on this network')
@@ -30,6 +30,9 @@ class Balancer(metaclass=Singleton):
 
     def is_balancer_pool(self, address: Address) -> bool:
         return is_balancer_pool_cached(address)
+
+    def get_version(self) -> str:
+        return "v1"
 
     @ttl_cache(ttl=600)
     def get_price(self, token: Address, block: Optional[Block] = None) -> float:
@@ -41,8 +44,8 @@ class Balancer(metaclass=Singleton):
         total = sum(balance * magic.get_price(token, block=block) for balance, token in zip(balances, tokens))
         return total / supply
 
-balancer = None
+balancer_v1 = None
 try:
-    balancer = Balancer()
+    balancer_v1 = BalancerV1()
 except UnsupportedNetwork:
     pass

--- a/yearn/prices/balancer/v1.py
+++ b/yearn/prices/balancer/v1.py
@@ -16,9 +16,7 @@ networks = [ Network.Mainnet ]
 def is_balancer_pool_cached(address: Address) -> bool:
     pool = contract(address)
     required = {"getCurrentTokens", "getBalance", "totalSupply"}
-    if set(pool.__dict__) & required == required:
-        return True
-    return False
+    return required.issubset(set(pool.__dict__))
 
 class BalancerV1(metaclass=Singleton):
     def __init__(self) -> None:

--- a/yearn/prices/balancer/v1.py
+++ b/yearn/prices/balancer/v1.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, List
 from brownie import chain
 from cachetools.func import ttl_cache
 
@@ -33,6 +33,10 @@ class BalancerV1(metaclass=Singleton):
 
     def get_version(self) -> str:
         return "v1"
+
+    def get_tokens(self, token: Address) -> List:
+        pool = contract(token)
+        return pool.getCurrentTokens()
 
     @ttl_cache(ttl=600)
     def get_price(self, token: Address, block: Optional[Block] = None) -> float:

--- a/yearn/prices/balancer/v2.py
+++ b/yearn/prices/balancer/v2.py
@@ -1,0 +1,52 @@
+from typing import Any, Literal, Optional
+from brownie import chain
+from cachetools.func import ttl_cache
+
+from yearn.cache import memory
+from yearn.multicall2 import fetch_multicall
+from yearn.prices import magic
+from yearn.utils import contract, Singleton
+from yearn.networks import Network
+from yearn.typing import Address, Block
+from yearn.exceptions import UnsupportedNetwork
+
+networks = [ Network.Mainnet ]
+
+@memory.cache()
+def is_balancer_pool_cached(address: Address) -> bool:
+    pool = contract(address)
+    required = {"getVault", "getPoolId", "totalSupply"}
+    if set(pool.__dict__) & required == required:
+        return True
+    return False
+
+class BalancerV2(metaclass=Singleton):
+    def __init__(self) -> None:
+        if chain.id not in networks:
+            raise UnsupportedNetwork('Balancer is not supported on this network')
+
+    def __contains__(self, token: Any) -> Literal[False]:
+        return False
+
+    def is_balancer_pool(self, address: Address) -> bool:
+        return is_balancer_pool_cached(address)
+
+    def get_version(self) -> str:
+        return "v2"
+
+    @ttl_cache(ttl=600)
+    def get_price(self, token: Address, block: Optional[Block] = None) -> float:
+        pool = contract(token)
+        pool_id = pool.getPoolId()
+        vault = pool.getVault()
+        tokens, supply = fetch_multicall([vault, "getPoolTokens", pool_id], [pool, "totalSupply"], block=block)
+        supply = supply / 1e18
+        balances = [balance / 10 ** contract(token).decimals() for token, balance in zip(tokens[0], tokens[1])]
+        total = sum(balance * magic.get_price(token, block=block) for token, balance in zip(tokens[0], tokens[1]))
+        return total / supply
+
+balancer_v2 = None
+try:
+    balancer_v2 = BalancerV2()
+except UnsupportedNetwork:
+    pass

--- a/yearn/prices/balancer/v2.py
+++ b/yearn/prices/balancer/v2.py
@@ -32,21 +32,21 @@ class BalancerV2(metaclass=Singleton):
     def get_version(self) -> str:
         return "v2"
 
-    def get_tokens(self, token: Address) -> List:
+    def get_tokens(self, token: Address, block: Optional[Block] = None) -> List:
         pool = contract(token)
         pool_id = pool.getPoolId()
         vault = contract(pool.getVault())
-        return vault.getPoolTokens(pool_id)[0]
+        return vault.getPoolTokens(pool_id, block_identifier=block)[0]
 
     @ttl_cache(ttl=600)
     def get_price(self, token: Address, block: Optional[Block] = None) -> float:
         pool = contract(token)
         pool_id = pool.getPoolId()
         vault = contract(pool.getVault())
-        tokens, supply = fetch_multicall([vault, "getPoolTokens", pool_id], [pool, "totalSupply"], block=block)
-        supply = supply / 1e18
-        balances = [balance / 10 ** contract(token).decimals() for token, balance in zip(tokens[0], tokens[1])]
-        total = sum(balance * magic.get_price(token, block=block) for token, balance in zip(tokens[0], tokens[1]))
+        tokens = vault.getPoolTokens(pool_id, block_identifier=block)
+        balances = [balance for t, balance in zip(tokens[0], tokens[1]) if t != token]
+        total = sum(balance * magic.get_price(t, block=block) for t, balance in zip(tokens[0], tokens[1]) if t != token)
+        supply = sum(balances)
         return total / supply
 
 balancer_v2 = None

--- a/yearn/prices/balancer/v2.py
+++ b/yearn/prices/balancer/v2.py
@@ -16,9 +16,7 @@ networks = [ Network.Mainnet ]
 def is_balancer_pool_cached(address: Address) -> bool:
     pool = contract(address)
     required = {"getVault", "getPoolId", "totalSupply"}
-    if set(pool.__dict__) & required == required:
-        return True
-    return False
+    return required.issubset(set(pool.__dict__))
 
 class BalancerV2(metaclass=Singleton):
     def __init__(self) -> None:

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -7,7 +7,7 @@ from cachetools.func import ttl_cache
 
 from yearn.exceptions import PriceError
 from yearn.networks import Network
-from yearn.prices import balancer as bal
+from yearn.prices.balancer import balancer as bal
 from yearn.prices import constants, curve
 from yearn.prices.aave import aave
 from yearn.prices.band import band
@@ -79,9 +79,11 @@ def find_price(
         price = uniswap_v2.lp_price(token, block=block)
         logger.debug("uniswap pool -> %s", price)
 
-    elif bal.balancer and bal.balancer.is_balancer_pool(token):
-        price = bal.balancer.get_price(token, block=block)
-        logger.debug("balancer pool -> %s", price)
+    elif bal.selector.has_balancers():
+        bal_for_pool = bal.balancers.get_balancer_for_pool(token)
+        if bal_for_pool:
+            price = bal_for_pool.get_price(token, block=block)
+            logger.debug("balancer %s pool -> %s", bal_for_pool.get_version(), price)
 
     elif yearn_lens and yearn_lens.is_yearn_vault(token):
         price = yearn_lens.get_price(token, block=block)

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -104,7 +104,11 @@ def find_price(
 
     elif chain.id == Network.Mainnet:
         # no liquid market for yveCRV-DAO -> return CRV token price
-        if token == Backscratcher().vault.address and block and block < 11786563:
+        if token == Backscratcher().vault.address and block < 11786563:
+            if curve.curve and curve.curve.crv:
+                return get_price(curve.curve.crv, block=block)
+        # no liquid market for yveCRV (yvecrv-f) -> return CRV token price
+        elif token == "0x7E46fd8a30869aa9ed55af031067Df666EfE87da" and block < 14987514:
             if curve.curve and curve.curve.crv:
                 return get_price(curve.curve.crv, block=block)
 

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -80,7 +80,7 @@ def find_price(
         logger.debug("uniswap pool -> %s", price)
 
     elif bal.selector.has_balancers():
-        bal_for_pool = bal.balancers.get_balancer_for_pool(token)
+        bal_for_pool = bal.selector.get_balancer_for_pool(token)
         if bal_for_pool:
             price = bal_for_pool.get_price(token, block=block)
             logger.debug("balancer %s pool -> %s", bal_for_pool.get_version(), price)

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -107,10 +107,9 @@ def find_price(
         if token == Backscratcher().vault.address and block < 11786563:
             if curve.curve and curve.curve.crv:
                 return get_price(curve.curve.crv, block=block)
-        # no liquid market for yveCRV (yvecrv-f) -> return CRV token price
+        # no liquidity for curve pool (yvecrv-f) -> return 0
         elif token == "0x7E46fd8a30869aa9ed55af031067Df666EfE87da" and block < 14987514:
-            if curve.curve and curve.curve.crv:
-                return get_price(curve.curve.crv, block=block)
+            return 0
 
     markets = [
         chainlink,

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -49,9 +49,15 @@ def unwrap_token(token: AddressOrContract) -> AddressString:
             return "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e"  # PPOOL -> POOL
 
     if chain.id in [ Network.Mainnet, Network.Fantom ]:
-        if aave and token in aave:
-            token = aave.atoken_underlying(token)
-            logger.debug("aave -> %s", token)
+        if aave:
+            asset = contract(token)
+            # wrapped aDAI -> aDAI
+            if "ATOKEN" in asset.__dict__:
+                token = asset.ATOKEN()
+
+            if token in aave:
+                token = aave.atoken_underlying(token)
+                logger.debug("aave -> %s", token)
 
     return token
 

--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -85,11 +85,10 @@ def find_price(
         price = uniswap_v2.lp_price(token, block=block)
         logger.debug("uniswap pool -> %s", price)
 
-    elif bal.selector.has_balancers():
+    elif bal.selector.get_balancer_for_pool(token):
         bal_for_pool = bal.selector.get_balancer_for_pool(token)
-        if bal_for_pool:
-            price = bal_for_pool.get_price(token, block=block)
-            logger.debug("balancer %s pool -> %s", bal_for_pool.get_version(), price)
+        price = bal_for_pool.get_price(token, block=block)
+        logger.debug("balancer %s pool -> %s", bal_for_pool.get_version(), price)
 
     elif yearn_lens and yearn_lens.is_yearn_vault(token):
         price = yearn_lens.get_price(token, block=block)

--- a/yearn/treasury/buckets.py
+++ b/yearn/treasury/buckets.py
@@ -3,7 +3,7 @@ from yearn.cache import memory
 from yearn.constants import BTC_LIKE
 from yearn.constants import ETH_LIKE as _ETH_LIKE
 from yearn.networks import Network
-from yearn.prices import balancer as bal
+from yearn.prices.balancer import balancer as bal
 from yearn.prices.aave import aave
 from yearn.prices.compound import compound
 from yearn.prices.constants import stablecoins, weth
@@ -94,11 +94,14 @@ def _unwrap_token(token) -> str:
             str(_unwrap_token(coin)) for coin in curve.get_underlying_coins(pool)
         )
         return _pool_bucket(pool_tokens)
-    if bal.balancer and bal.balancer.is_balancer_pool(token):  # should only be YLA # TODO figure this out
-        pool_tokens = set(
-            str(_unwrap_token(coin)) for coin in contract(token).getCurrentTokens()
-        )
-        return _pool_bucket(pool_tokens)
+    if bal.selector.has_balancers():
+        # should only be YLA # TODO figure this out
+        bal_for_pool = bal.selector.get_balancer_for_pool(token)
+        if bal_for_pool:
+            pool_tokens = set(
+                str(_unwrap_token(coin)) for coin in bal_for_pool.get_tokens()
+            )
+            return _pool_bucket(pool_tokens)
     if aave and token in aave:
         return aave.atoken_underlying(token)
     if compound and token in compound:

--- a/yearn/treasury/buckets.py
+++ b/yearn/treasury/buckets.py
@@ -94,14 +94,13 @@ def _unwrap_token(token) -> str:
             str(_unwrap_token(coin)) for coin in curve.get_underlying_coins(pool)
         )
         return _pool_bucket(pool_tokens)
-    if bal.selector.has_balancers():
+    if bal.selector.get_balancer_for_pool(token):
         # should only be YLA # TODO figure this out
         bal_for_pool = bal.selector.get_balancer_for_pool(token)
-        if bal_for_pool:
-            pool_tokens = set(
-                str(_unwrap_token(coin)) for coin in bal_for_pool.get_tokens()
-            )
-            return _pool_bucket(pool_tokens)
+        pool_tokens = set(
+            str(_unwrap_token(coin)) for coin in bal_for_pool.get_tokens()
+        )
+        return _pool_bucket(pool_tokens)
     if aave and token in aave:
         return aave.atoken_underlying(token)
     if compound and token in compound:


### PR DESCRIPTION
Added functionality for discovering prices for:
- [x] balancer v2 pools: e.g. `bb-a-USD` [0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2](https://etherscan.io/address/0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2)
- [x] wrapped aave tokens: e.g. `wrapped aDAI` [0x02d60b84491589974263d922d9cc7a3152618ef6](https://etherscan.io/token/0x02d60b84491589974263d922d9cc7a3152618ef6)
- [x] curve factory pool with no liquidity before a specific block: `yveCRV (yvecrv-f)` [0x7E46fd8a30869aa9ed55af031067Df666EfE87da](https://etherscan.io/address/0x7E46fd8a30869aa9ed55af031067Df666EfE87da) 