### PR TITLE
fix: grafana dashboard overview

### DIFF
--- a/grafana/provisioning/dashboards/yearn/Overview.json
+++ b/grafana/provisioning/dashboards/yearn/Overview.json
@@ -156,7 +156,7 @@
                 "config": {
                   "id": "lowerOrEqual",
                   "options": {
-                    "value": 1000000000
+                    "value": 10000000
                   }
                 },
                 "fieldName": "tvl"


### PR DESCRIPTION
- lower the limit on the filter for a view from 1b to 10k usd