### PR TITLE
fix: move the partner processing to a new container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,17 +60,17 @@ all:
 	$(all_command) down && $(all_command) build --no-cache && $(all_command) up $(flags)
 
 logs-all:
-	$(dashboards_command) logs -f -t eth-exporter historical-eth-exporter ftm-exporter historical-ftm-exporter treasury-exporter historical-treasury-exporter ftm-treasury-exporter historical-ftm-treasury-exporter sms-exporter historical-sms-exporter ftm-sms-exporter historical-ftm-sms-exporter transactions-exporter wallet-exporter ftm-transactions-exporter ftm-wallet-exporter
+	$(dashboards_command) logs -f -t eth-exporter historical-eth-exporter ftm-exporter historical-ftm-exporter treasury-exporter historical-treasury-exporter ftm-treasury-exporter historical-ftm-treasury-exporter sms-exporter historical-sms-exporter ftm-sms-exporter historical-ftm-sms-exporter transactions-exporter wallet-exporter ftm-transactions-exporter ftm-wallet-exporter partners-exporter ftm-partners-exporter
 
 postgres:
 	$(dashboards_command) up -d --build postgres
 
 # Mainnet:
 mainnet:
-	$(all_command) up -d --build eth-exporter historical-eth-exporter treasury-exporter historical-treasury-exporter sms-exporter historical-sms-exporter transactions-exporter wallet-exporter
+	$(all_command) up -d --build eth-exporter historical-eth-exporter treasury-exporter historical-treasury-exporter sms-exporter historical-sms-exporter transactions-exporter wallet-exporter partners-exporter
 
 logs-mainnet:
-	$(all_command) logs -ft eth-exporter historical-eth-exporter treasury-exporter historical-treasury-exporter sms-exporter historical-sms-exporter transactions-exporter wallet-exporter
+	$(all_command) logs -ft eth-exporter historical-eth-exporter treasury-exporter historical-treasury-exporter sms-exporter historical-sms-exporter transactions-exporter wallet-exporter partners-exporter
 
 eth:
 	make mainnet
@@ -80,10 +80,10 @@ logs-eth:
 
 # Fantom:
 fantom:
-	$(all_command) up -d --build ftm-exporter historical-ftm-exporter ftm-treasury-exporter historical-ftm-treasury-exporter ftm-sms-exporter historical-ftm-sms-exporter ftm-transactions-exporter ftm-wallet-exporter
+	$(all_command) up -d --build ftm-exporter historical-ftm-exporter ftm-treasury-exporter historical-ftm-treasury-exporter ftm-sms-exporter historical-ftm-sms-exporter ftm-transactions-exporter ftm-wallet-exporter ftm-partners-exporter
 
 logs-fantom:
-	$(all_command) logs -ft ftm-exporter historical-ftm-exporter ftm-treasury-exporter historical-ftm-treasury-exporter ftm-sms-exporter historical-ftm-sms-exporter ftm-transactions-exporter ftm-wallet-exporter
+	$(all_command) logs -ft ftm-exporter historical-ftm-exporter ftm-treasury-exporter historical-ftm-treasury-exporter ftm-sms-exporter historical-ftm-sms-exporter ftm-transactions-exporter ftm-wallet-exporter ftm-partners-exporter
 	
 
 # Gnosis chain:

--- a/scripts/partners_exporter.py
+++ b/scripts/partners_exporter.py
@@ -18,7 +18,6 @@ sleep_interval = int(os.environ.get('SLEEP_SECONDS', '0'))
 
 
 def export_partners(block):
-    metrics_to_export = []
     for partner in partners:
         # collect payout data
         data, _ = partner.process()
@@ -27,6 +26,7 @@ def export_partners(block):
         data = data.loc[data.index <= block.number]
 
         # export wrapper data
+        metrics_to_export = []
         for wrapper in set(data.wrapper):
             wrapper_info = {}
 
@@ -61,7 +61,7 @@ def export_partners(block):
                     block.timestamp
                 )
                 metrics_to_export.append(item)
-    _post(metrics_to_export)
+        _post(metrics_to_export)
 
 
 def main():

--- a/scripts/partners_exporter.py
+++ b/scripts/partners_exporter.py
@@ -1,0 +1,80 @@
+import logging
+import os
+import time
+
+import sentry_sdk
+from brownie import chain
+
+from yearn.outputs.victoria import output_duration
+from yearn.outputs.victoria.output_treasury import _get_symbol
+from yearn.outputs.victoria.output_helper import _build_item, _post
+from yearn.treasury.buckets import get_token_bucket
+from yearn.partners.partners import partners
+
+sentry_sdk.set_tag('script','partners_exporter')
+
+logger = logging.getLogger('yearn.partners_exporter')
+sleep_interval = int(os.environ.get('SLEEP_SECONDS', '0'))
+
+label_names = ['partner', 'param', 'token_address', 'token', 'bucket']
+
+
+def build_item(partner, token, key, value, timestamp):
+    symbol = _get_symbol(token)
+    bucket = get_token_bucket(token)
+    return _build_item(
+        "partners",
+        label_names,
+        [partner, key, token, symbol, bucket],
+        value,
+        timestamp
+    )
+
+
+def export_partners(block):
+    metrics_to_export = []
+    for partner in partners:
+        # collect payout data
+        data, _ = partner.process()
+        if len(data) == 0:
+            continue
+        data = data.loc[data.index <= block.number]
+
+        # export wrapper data
+        for wrapper in set(data.wrapper):
+            wrapper_info = {}
+
+            wrapper_data = data[data.wrapper == wrapper]
+            if len(wrapper_data) == 0:
+                continue
+            token = wrapper_data.vault.iloc[-1]
+
+            # wrapper balance
+            wrapper_info["balance"] = float(wrapper_data.balance.iloc[-1])
+            wrapper_info["balance_usd"] = float(wrapper_data.balance_usd.iloc[-1])
+
+            # wrapper payouts
+            wrapper_daily_data = wrapper_data.set_index('timestamp').resample('1D').sum()
+            wrapper_info["payout_daily"] = float(wrapper_daily_data.payout.iloc[-1])
+            wrapper_info["payout_weekly"] = float(wrapper_daily_data.payout.iloc[-7:].sum())
+            wrapper_info["payout_monthly"] = float(wrapper_daily_data.payout.iloc[-30:].sum())
+            wrapper_info["payout_total"] = float(wrapper_daily_data.payout.sum())
+            wrapper_info["payout_usd_daily"] = float(wrapper_daily_data.payout_usd.iloc[-1])
+            wrapper_info["payout_usd_weekly"] = float(wrapper_daily_data.payout_usd.iloc[-7:].sum())
+            wrapper_info["payout_usd_monthly"] = float(wrapper_daily_data.payout_usd.iloc[-30:].sum())
+            wrapper_info["payout_usd_total"] = float(wrapper_daily_data.payout_usd.sum())
+
+            for key, value in wrapper_info.items():
+                metrics_to_export.append(
+                    build_item(partner.name, token, key, value, block.timestamp)
+                )
+    _post(metrics_to_export)
+
+
+def main():
+    for block in chain.new_blocks(height_buffer=12):
+        start_time = time.time()
+        export_partners(block)
+        duration = time.time() - start_time
+        output_duration.export(duration, 1, "partners_forwards", block.timestamp)
+        time.sleep(sleep_interval)

--- a/scripts/partners_exporter.py
+++ b/scripts/partners_exporter.py
@@ -70,4 +70,5 @@ def main():
         export_partners(block)
         duration = time.time() - start_time
         output_duration.export(duration, 1, "partners_forwards", block.timestamp)
+        logger.info('exported block=%d took=%.3fs', block.number, time.time() - start_time)
         time.sleep(sleep_interval)

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -383,6 +383,37 @@ services:
       - victoria-metrics
       - postgres
 
+  partners-exporter:
+    image: yearn-exporter
+    command: partners_exporter
+    volumes: *common-volumes
+    environment:
+      <<: *common-envs
+      <<: *common-eth-envs
+      <<: *common-historical-envs
+      <<: *common-postgres-envs
+    networks:
+      - yearn-exporter
+    restart: on-failure
+    depends_on:
+      - victoria-metrics
+      - postgres
+
+  ftm-partners-exporter:
+    image: yearn-exporter
+    command: partners_exporter
+    volumes: *common-volumes
+    environment:
+      <<: *common-envs
+      <<: *common-ftm-envs
+      <<: *common-postgres-envs
+    networks:
+      - yearn-exporter
+    restart: on-failure
+    depends_on:
+      - victoria-metrics
+      - postgres
+
   vmagent:
     image: victoriametrics/vmagent:heads-public-single-node-0-g52eb9c99e
     volumes:

--- a/yearn/outputs/victoria/output_treasury.py
+++ b/yearn/outputs/victoria/output_treasury.py
@@ -4,13 +4,7 @@ from yearn.utils import contract
 
 def export(timestamp, data, label):
     metrics_to_export = []
-
     for section, section_data in data.items():
-        # handle partners data
-        if section == 'partners':
-            export_partners(timestamp, section_data, label)
-            continue
-
         for wallet, wallet_data in section_data.items():
             for token, bals in wallet_data.items():
                 symbol = _get_symbol(token)
@@ -31,54 +25,3 @@ def _get_symbol(token):
         return contract(token).symbol()
     except AttributeError:
         return None
-
-
-def export_partners(timestamp, data, label):
-    metrics_to_export = []
-    label_names = ['partner', 'param', 'token_address', 'token', 'bucket']
-    for partner, partner_data in data.items():
-        for wrapper, wrapper_data in partner_data.items():
-            # get vault token
-            token = wrapper_data.get('vault')
-            if token is None:
-                continue
-            symbol = _get_symbol(token)
-            bucket = get_token_bucket(token)
-
-            # wrapper balance
-            for key in ['balance', 'balance_usd']:
-                item = _build_item(
-                    "partners",
-                    label_names,
-                    [partner, key, token, symbol, bucket],
-                    wrapper_data.get(key, 0.0),
-                    timestamp
-                )
-                metrics_to_export.append(item)
-
-            # payouts
-            payout = wrapper_data.get('payout', {})
-            for interval, value in payout.items():
-                key = f"payout_{interval}"
-                item = _build_item(
-                    "partners",
-                    label_names,
-                    [partner, key, token, symbol, bucket],
-                    value,
-                    timestamp
-                )
-                metrics_to_export.append(item)
-            payout_usd = wrapper_data.get('payout_usd', {})
-            for interval, value in payout_usd.items():
-                key = f"payout_usd_{interval}"
-                item = _build_item(
-                    "partners",
-                    label_names,
-                    [partner, key, token, symbol, bucket],
-                    value,
-                    timestamp
-                )
-                metrics_to_export.append(item)
-
-    # post all metrics for this timestamp at once
-    _post(metrics_to_export)

--- a/yearn/partners/snapshot.py
+++ b/yearn/partners/snapshot.py
@@ -12,7 +12,7 @@ from brownie import Contract, chain, convert, multicall, web3
 from joblib.parallel import Parallel, delayed
 from pandas import DataFrame
 from pandas.core.tools.datetimes import DatetimeScalar
-from pony.orm import OperationalError, db_session
+from pony.orm import OperationalError, db_session, commit
 from rich import print
 from rich.progress import track
 from web3._utils.abi import filter_by_name
@@ -451,3 +451,4 @@ def cache_data(wrap: DataFrame) -> None:
             wrapper=cache_address(row.wrapper),
             vault=cache_token(row.vault),
         )
+        commit()


### PR DESCRIPTION
Aims to split the partners-related processing to a new container named partners-exporter,
to solve the data race issue caused by #349.