### PR TITLE
feat: add optimism network support

### DIFF
--- a/yearn/multicall2.py
+++ b/yearn/multicall2.py
@@ -17,6 +17,7 @@ MULTICALL2 = {
     Network.Gnosis: '0xFAa296891cA6CECAF2D86eF5F7590316d0A17dA0', # maker has not yet deployed multicall2. This is from another deployment
     Network.Fantom: '0xD98e3dBE5950Ca8Ce5a4b59630a5652110403E5c',
     Network.Arbitrum: '0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858',
+    Network.Optimism: '0xcA11bde05977b3631167028862bE2a173976CA11' # Multicall 3
 }
 multicall2 = contract(MULTICALL2[chain.id])
 

--- a/yearn/networks.py
+++ b/yearn/networks.py
@@ -10,6 +10,7 @@ class Network(IntEnum):
     Gnosis = 100
     Fantom = 250
     Arbitrum = 42161
+    Optimism = 10
 
     @staticmethod
     def label(chain_id: int = None):
@@ -23,7 +24,9 @@ class Network(IntEnum):
         elif chain_id == Network.Fantom:
             return "FTM"
         elif chain_id == Network.Arbitrum:
-            return "ARBB"
+            return "ARRB"
+        elif chain_id == Network.Optimism:
+            return "OPT"
         else:
             raise UnsupportedNetwork(
                 f'chainid {chain_id} is not currently supported. Please add network details to yearn-exporter/yearn/networks.py'

--- a/yearn/prices/constants.py
+++ b/yearn/prices/constants.py
@@ -23,6 +23,11 @@ tokens_by_network = {
         'usdc': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
         'dai': '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
     },
+    Network.Optimism: {
+        'weth': '0x4200000000000000000000000000000000000006',
+        'usdc': '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
+        'dai': '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
+    }
 }
 
 stablecoins_by_network = {
@@ -76,13 +81,21 @@ stablecoins_by_network = {
         '0xFEa7a6a0B346362BF88A9e4A88416B77a57D6c2A': 'mim',
         '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 'usdt'
     },
+    Network.Optimism: {
+        '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58': 'usdt',
+        '0x7F5c764cBc14f9669B88837ca1490cCa17c31607': 'usdc',
+        '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': 'dai',
+        '0x2E3D870790dC77A83DD1d18184Acc7439A53f475': 'frax',
+        '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9': 'susd',
+    }
 }
 
 ib_snapshot_block_by_network = {
     Network.Mainnet: 14051986,
     Network.Fantom: 28680044,
     Network.Gnosis: 1, # TODO revisit as IB is not deployed in gnosis
-    Network.Arbitrum: 1
+    Network.Arbitrum: 1,
+    Network.Optimism: 1  
 }
 
 # We convert to checksum address here to prevent minor annoyances. It's worth it.


### PR DESCRIPTION
# To do

You must add the following constants:

- in ./yearn/networks.py:
- [x] specify the chainid in the same way as the others.
- [x] specify a network label in `Networks.label`.

- in ./yearn/constants.py:
- [ ] specify Treasury address. (if Yearn has a treasury contract deployed) This would be the rewards() address of any vault.
- [ ] specify Multisig address. This would be the governance() address of any vault
- [ ] specify Strategist Multisig address. (if Yearn has a SMS deployed) This would be the management() address of any vault.

- in ./yearn/prices/constants.py:
- [x] add weth address to `tokens_by_network`.
- [x] add usdc address to `tokens_by_network`.
- [x] add dai address to `tokens_by_network`.
- [x] configure `stablecoins` using popular + "safe" stablecoins on the chain.

- in ./yearn/multicall2.py:
- [x] specify the appropriate multicall2 contract address.

- in ./yearn/prices/chainlink.py:
- [ ] specify any chainlink feeds available on the chain in `feeds`.
- [ ] specify the chainlink registry address in `registries` if applicable, or specify None if not applicable.

- in ./yearn/prices/uniswap/v2.py:
- [ ] specify the factory and router address for any important uni v2 forks on the chain.

- in ./yearn/utils.py:
- [ ] specify `BINARY_SEARCH_BARRIER` as 0 if all historical data is available. If historical data not available due to a network upgrade/etc, specify the first block of the available historical data.

- in ./yearn/middleware/middleware.py:
- [ ] specify `BATCH_SIZE` of approx 1 day based on avg block times on the chain.

- in ./scripts/historical-exporter.py:
- [ ] configure `end` to equal the date + hour of deployment for the first Yearn product on the chain.
- [ ] configure `data_query`. See `mapping` in ./yearn/outputs/victoria/output_helper.py to figure out the metric to specify based on what type of product was the first deployed on the chain.

- in ./scripts/historical-treasury-exporter.py:
- [ ] configure `end` to equal the date + hour of deployment for the Yearn Treasury on the chain.
- [ ] configure `data_query` using the existing networks as an example.

- in ./scripts/historical-sms-exporter.py:
- [ ] configure `end` to equal the date + hour of deployment for the Strategist Multisig on the chain.
- [ ] configure `data_query` using the existing networks as an example.


You also need to set up containers for each exporter on the new chain. This is a little more complicated but you can use existing containers as an example:
- [ ] define common envs for the chain
- [ ] add one new service entry for forwards exporter
- [ ] add one new service entry for historical exporter
- [ ] add one new service entry for treasury exporter
- [ ] add one new service entry for historical treasury exporter
- [ ] add one new service entry for sms exporter
- [ ] add one new service entry for historical sms exporter
- [ ] add one new service entry for wallet exporter
- [ ] add one new service entry for transactions exporter
- [ ] adapt entrypoint.sh


There still may be some things I'm missing, so its important to test to make sure everything works!

Once you've handled everything above, type `make all && make logs-all` into your terminal at the project root. The exporters will start running in docker and any exceptions will show in your terminal. If there are no exceptions, and everything appears to be running smoothly, it's time to submit your PR!