### PR TITLE
feat: add arbitrum exporters #354

### DIFF
--- a/scripts/historical_exporter.py
+++ b/scripts/historical_exporter.py
@@ -24,6 +24,10 @@ def main():
         # end: yvUSDC vault January-20-2022 06:10:45 AM +-6 UTC
         end = datetime(2022, 1, 20, tzinfo=timezone.utc)
         data_query = 'yearn_vault{network="GNO"}'
+    elif Network(chain.id) == Network.Arbitrum:
+        # end: Jan-21-2022 01:41:42 AM +UTC
+        end = datetime(2022, 1, 21, tzinfo=timezone.utc)
+        data_query = None #TODO: not sure what to add here yet
     else:
         # end: 2020-02-12 first iearn deployment
         end = datetime(2020, 2, 12, 0, 1, tzinfo=timezone.utc)

--- a/scripts/historical_sms_exporter.py
+++ b/scripts/historical_sms_exporter.py
@@ -21,6 +21,7 @@ def main():
         Network.Mainnet: datetime(2021, 1, 28, 9, 10, tzinfo=timezone.utc), # first inbound sms tx
         Network.Fantom: datetime(2021, 6, 17, tzinfo=timezone.utc), # Fantom SMS deployed
         Network.Gnosis: datetime(2022, 2, 3, 23, 45, tzinfo=timezone.utc), # Block 20455212, first tx in SMS
+        Network.Arbitrum: datetime(2022, 10, 21, 9, 20, 38, tzinfo=timezone.utc) # https://arbiscan.io/tx/0x9f8de852b7bfb3122469fbd846fd3367db77a9d6399d61ba65224958af101066
     }[chain.id]
 
     export_historical(

--- a/scripts/historical_treasury_exporter.py
+++ b/scripts/historical_treasury_exporter.py
@@ -20,6 +20,7 @@ def main():
         Network.Mainnet: datetime(2020, 7, 21, 10, 1, tzinfo=timezone.utc), # first treasury tx
         Network.Fantom: datetime(2021, 10, 12, tzinfo=timezone.utc), # Fantom Multisig deployed
         Network.Gnosis: datetime(2022, 1, 8, 2, 20, 50, tzinfo=timezone.utc), # Block 20_000_000, some time near the first tx in the Gnosis treasury EOA. Further testing is needed to confirm as first tx was not fully apparent on block explorer. 
+        Network.Arbitrum: datetime(2022, 1, 20, 11, 14, 1, tzinfo=timezone.utc) # https://arbiscan.io/tx/0x69411870b77b9539ca48b6d0b291a05ac399acdf1639b573ff57c1b2ba0987cd
     }[chain.id]
 
     export_historical(

--- a/yearn/constants.py
+++ b/yearn/constants.py
@@ -139,6 +139,9 @@ STRATEGIST_MULTISIG = {
     },
     Network.Gnosis: {
         "0xFB4464a18d18f3FF439680BBbCE659dB2806A187"
+    },
+    Network.Arbitrum: {
+        "0x6346282DB8323A54E840c6C772B4399C9c655C0d",
     }
 }.get(chain.id,set())
 
@@ -146,11 +149,13 @@ YCHAD_MULTISIG = {
     Network.Mainnet:    "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52",
     Network.Fantom:     "0xC0E2830724C946a6748dDFE09753613cd38f6767",
     Network.Gnosis:     "0x22eAe41c7Da367b9a15e942EB6227DF849Bb498C",
+    Network.Arbitrum:   "0xb6bc033D34733329971B938fEf32faD7e98E56aD",
 }.get(chain.id, None)
 
 TREASURY_MULTISIG = {
     Network.Mainnet:    "0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde",
     Network.Fantom:     "0x89716Ad7EDC3be3B35695789C475F3e7A3Deb12a",
+    Network.Arbitrum:   "0x1DEb47dCC9a35AD454Bf7f0fCDb03c09792C08c1",
 }.get(chain.id, None)
 
 TREASURY_WALLETS = {

--- a/yearn/prices/chainlink.py
+++ b/yearn/prices/chainlink.py
@@ -50,7 +50,6 @@ ADDITIONAL_FEEDS = {
         "0xe105621721D1293c27be7718e041a4Ce0EbB227E": "0x3E68e68ea2c3698400465e3104843597690ae0f7",  # feur
         "0x29b0Da86e484E1C0029B56e817912d778aC0EC69": "0x9B25eC3d6acfF665DfbbFD68B3C1D896E067F0ae",  # yfi
     },
-
     Network.Gnosis: {
         "0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252" : "0x6c1d7e76ef7304a40e8456ce883bc56d3dea3f7d", # wbtc
         "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1" : "0xa767f745331d267c7751297d982b050c93985627", # weth
@@ -64,6 +63,10 @@ ADDITIONAL_FEEDS = {
         "0xbf65bfcb5da067446CeE6A706ba3Fe2fB1a9fdFd" : "0x14030d5a0c9e63d9606c6f2c8771fc95b34b07e0", # yfi
         "0x7f7440C5098462f833E123B44B8A03E1d9785BAb" : "0xfdf9eb5fafc11efa65f6fd144898da39a7920ae8", # 1inch
         "0xDf6FF92bfDC1e8bE45177DC1f4845d391D3ad8fD" : "0xba95bc8418ebcdf8a690924e1d4ad5292139f2ea", # comp
+    },
+    # https://data.chain.link/arbitrum/mainnet
+    Network.Arbitrum: {
+        # TODO: add data
     }
 }
 registries = {
@@ -71,6 +74,7 @@ registries = {
     Network.Mainnet: '0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf',
     Network.Fantom: None,
     Network.Gnosis: None,
+    Network.Arbitrum: None,
 }
 
 

--- a/yearn/prices/constants.py
+++ b/yearn/prices/constants.py
@@ -37,7 +37,6 @@ stablecoins_by_network = {
         "0x853d955aCEf822Db058eb8505911ED77F175b99e": "frax",
         "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0": "lusd",
         "0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9": "alusd",
-        "0x0000000000085d4780B73119b644AE5ecd22b376": "tusd",
         "0x1c48f86ae57291F7686349F12601910BD8D470bb": "usdk",
         "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd": "gusd",
         "0x0E2EC54fC0B509F445631Bf4b91AB8168230C752": "linkusd",
@@ -70,6 +69,8 @@ stablecoins_by_network = {
     Network.Arbitrum: {
         '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8': 'usdc',
         '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': 'dai',
+        '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 'usdt',
+        '0x4D15a3A2286D883AF0AA1B3f21367843FAc63E07': 'tusd',
     },
 }
 
@@ -77,7 +78,7 @@ ib_snapshot_block_by_network = {
     Network.Mainnet: 14051986,
     Network.Fantom: 28680044,
     Network.Gnosis: 1, # TODO revisit as IB is not deployed in gnosis
-    Network.Arbitrum: 1
+    Network.Arbitrum: 1 # TODO revisit as IB is not deployed in arbitrum
 }
 
 weth = tokens_by_network[chain.id]['weth']

--- a/yearn/prices/uniswap/v2.py
+++ b/yearn/prices/uniswap/v2.py
@@ -50,6 +50,7 @@ addresses: List[Dict[str,str]] = {
             'router': '0x16327E3FbDaCA3bcF7E38F5Af2599D2DDc33aE52',
         },
     ],
+    Network.Arbitrum: [], #TODO: add data
 }
 
 


### PR DESCRIPTION
#354

- [ ]  define common envs for the chain
- [ ]  add one new service entry for forwards exporter
- [ ]  add one new service entry for historical exporter
- [ ]  add one new service entry for treasury exporter
- [ ]  add one new service entry for historical treasury exporter
- [ ]  add one new service entry for sms exporter
- [ ]  add one new service entry for historical sms exporter
- [ ]  add one new service entry for wallet exporter
- [ ]  add one new service entry for transactions exporter
- [ ]  adapt entrypoint.sh