### PR TITLE
feat: adding a basic revenue script that publishes revenue data to s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,3 +208,7 @@ logs-treasury-tx:
 # apy scripts
 apy: commands=s3
 apy: up
+
+# revenue scripts
+revenues:
+	make up network=eth commands=revenues

--- a/scripts/revenues.py
+++ b/scripts/revenues.py
@@ -1,0 +1,82 @@
+import os
+import psycopg2
+import csv
+import boto3
+import sentry_sdk
+import logging
+import yearn
+from datetime import datetime
+
+sentry_sdk.set_tag('script','revenues')
+logger = logging.getLogger(__name__)
+
+def main():
+    debug = os.getenv("DEBUG", None)
+
+    today = datetime.today()
+    from_str = os.getenv("REVENUES_FROM", today.replace(day=1).strftime('%Y-%m-%d'))
+    to_str   = os.getenv("REVENUES_TO", today.strftime('%Y-%m-%d'))
+    file_name = f"revenues_{from_str}_{to_str}.csv"
+    file_path = f"/tmp/{file_name}"
+
+    _export_data(from_str, to_str, file_path)
+
+    if debug:
+        logger.info("Printing CSV file contents of %s", file_path)
+        with open(file_path) as file:
+            reader = csv.reader(file, delimiter=';', quotechar='"')
+            for row in reader:
+                print(row)
+    else:
+        # upload the file to the s3 bucket
+        s3_bucket = os.environ.get("REVENUES_S3_BUCKET")
+        s3_path = f'{os.environ.get("REVENUES_S3_PATH")}/{file_name}'
+        s3 = _get_s3()
+        s3.upload_file(
+            file_path,
+            s3_bucket,
+            s3_path,
+            ExtraArgs={'ContentType': "application/csv", 'CacheControl': "max-age=1800"},
+        )
+        logger.info("successfully uploaded file '%s' to '%s'", file_path, s3_path)
+
+        # cleanup
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info("deleted file '%s'", file_path)
+
+
+def _export_data(from_str, to_str, file_path):
+    sql = f"COPY (\
+SELECT * FROM general_ledger \
+WHERE timestamp::date BETWEEN '{from_str}' AND '{to_str}' ORDER BY timestamp\
+) TO STDOUT WITH CSV DELIMITER ';' HEADER QUOTE AS '\"'"
+
+    conn = _get_db_connection()
+    with open(file_path, "w") as file:
+        cur = conn.cursor()
+        cur.copy_expert(sql, file)
+    conn.close()
+    logger.info("Exported revenues data from '%s' to '%s' to '%s'", from_str, to_str, file_path)
+
+
+def _get_db_connection():
+    dbname = os.getenv("PGDATABASE", "postgres")
+    user = os.getenv("PGUSER", "postgres")
+    password = os.getenv("PGPASSWORD", "postgres")
+    host = os.getenv("PGHOST", "localhost")
+    port = os.getenv("PGPORT", 5432)
+    return psycopg2.connect(f"dbname={dbname} user={user} password={password} host={host}, port={port}")
+
+
+def _get_s3():
+    aws_key = os.environ.get("REVENUES_AWS_KEY_ID")
+    aws_secret = os.environ.get("REVENUES_AWS_SECRET_ACCESS_KEY")
+
+    kwargs = {}
+    if aws_key:
+        kwargs["aws_access_key_id"] = aws_key
+    if aws_secret:
+        kwargs["aws_secret_access_key"] = aws_secret
+
+    return boto3.client("s3", **kwargs)

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -37,6 +37,14 @@ x-apy-envs: &apy-envs
   - EXPORT_MODE:
   - DEBUG_ADDRESS:
 
+x-revenues-envs: &revenues-envs
+  - REVENUES_AWS_KEY_ID:
+  - REVENUES_AWS_SECRET_ACCESS_KEY:
+  - REVENUES_S3_BUCKET:
+  - REVENUES_S3_PATH:
+  - REVENUES_FROM:
+  - REVENUES_TO:
+
 x-network-envs: &network-envs
   - BROWNIE_NETWORK:
   - WEB3_PROVIDER:
@@ -50,6 +58,7 @@ x-network-envs: &network-envs
 
 x-postgres-envs: &postgres-envs
   - PGHOST: postgres
+  - PGPORT: 5432
   - PGDATABASE: postgres
   - PGUSER: postgres
   - PGPASSWORD: yearn-exporter
@@ -68,6 +77,7 @@ services:
       <<: *postgres-envs
       <<: *network-envs
       <<: *apy-envs
+      <<: *revenues-envs
     networks:
       - infra_yearn-exporter
     external_links:


### PR DESCRIPTION
In order to test without uploading to s3 you can try: `DEBUG=true make revenues`
This will dump the result data to stdout.

By default the script sets the first of month as `from` and the current date as `to` for the range query.
You can override it by passing `REVENUES_FROM` or `REVENUES_TO` env variables.