### PR TITLE
Fix/experimental vaults keep crv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ shell: get-network-name
 
 .ONESHELL:
 debug-apy: get-network-name
-	DEBUG=true docker-compose --file services/dashboard/docker-compose.yml --project-directory . run --rm --entrypoint "brownie run --network $(BROWNIE_NETWORK) debug_apy -I" exporter
+	DEBUG=true docker-compose --file services/dashboard/docker-compose.yml --project-directory . run --rm --entrypoint "brownie run --network $(BROWNIE_NETWORK) debug_apy with_exception_handling -I" exporter
 	make logs filter=debug
 
 list-networks:

--- a/scripts/debug_apy.py
+++ b/scripts/debug_apy.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import traceback
 from yearn.v2.vaults import Vault
 from yearn.apy.common import get_samples
 from yearn.debug import Debug
@@ -11,9 +12,17 @@ def main():
   if address:
     vault = Vault.from_address(address)
     vault.apy(get_samples())
-    collected_variables = Debug().get_collected_variables()
-    logger.info("*** Available variables for debugging ***")
-    available_variables = [ k for k in locals().keys() if '__' not in k and 'pdb' not in k and 'self' != k and 'sys' != k ]
-    logger.info(available_variables)
   else:
     print("no address specified via $DEBUG_ADDRESS")
+
+def with_exception_handling():
+    try:
+        main()
+    except Exception as e:
+        traceback.print_exc()
+        logger.error(e)
+    finally:
+        collected_variables = Debug().get_collected_variables()
+        logger.info("*** Available variables for debugging ***")
+        available_variables = [ k for k in locals().keys() if '__' not in k and 'pdb' not in k and 'self' != k and 'sys' != k ]
+        logger.info(available_variables)

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -281,6 +281,9 @@ class _ConvexVault:
         # some strategies have a localCRV property which is used based on a flag, otherwise
         # falling back to the global curve config contract.
         # note the spelling mistake in the variable name uselLocalCRV
+        if os.getenv("DEBUG", None):
+            logger.info(pformat(Debug().collect_variables(locals())))
+
         if hasattr(self._cvx_strategy, "uselLocalCRV"):
             use_local_crv = self._cvx_strategy.uselLocalCRV(block_identifier=self.block)
             if use_local_crv:

--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -291,8 +291,13 @@ class _ConvexVault:
             else:
                 curve_global = contract(self._cvx_strategy.curveGlobal(block_identifier=self.block))
                 cvx_keep_crv = curve_global.keepCRV(block_identifier=self.block) / 1e4
-        else: 
+        elif hasattr(self._cvx_strategy, "keepCRV"):
             cvx_keep_crv = self._cvx_strategy.keepCRV(block_identifier=self.block) / 1e4
+        else:
+            # the experimental vault 0xe92AE2cF5b373c1713eB5855D4D3aF81D8a8aCAE yvCurvexFraxTplLP-U
+            # has a strategy 0x06aee67AC42473E9F0e7DC1A6687A1F26C8136A3 ConvexTempleDAO-U which doesn't have
+            # uselLocalCRV nor keepCRV
+            cvx_keep_crv = 0
 
         cvx_booster = contract(addresses[chain.id]['convex_booster'])
         cvx_fee = self._get_convex_fee(cvx_booster, self.block)


### PR DESCRIPTION
For a dry run of apy calculations for experimental vaults on eth mainnet you can do:
`DEBUG=true EXPORT_MODE=experimental make apy network=eth`