### PR TITLE
fix: guard usage of chainlink feeds per network

### DIFF
--- a/yearn/apy/common.py
+++ b/yearn/apy/common.py
@@ -58,7 +58,7 @@ def calculate_roi(after: SharePricePoint, before: SharePricePoint) -> float:
     # calculate our average blocks per day in the past week
     now = web3.eth.block_number
     now_time = datetime.today()
-    blocks_per_day = int((now - closest_block_after_timestamp((now_time - timedelta(days=7)).timestamp())) / 7)
+    blocks_per_day = int((now - closest_block_after_timestamp((now_time - timedelta(days=7)).timestamp(), True)) / 7)
     
     # calculate our annualized return for a vault
     pps_delta = (after.price - before.price) / (before.price or 1)
@@ -73,7 +73,7 @@ def get_samples(now_time: Optional[datetime] = None) -> ApySamples:
         now_time = datetime.today()
         now = web3.eth.block_number
     else:
-        now = closest_block_after_timestamp(now_time.timestamp())
-    week_ago = closest_block_after_timestamp((now_time - timedelta(days=7)).timestamp())
-    month_ago = closest_block_after_timestamp((now_time - timedelta(days=31)).timestamp())
+        now = closest_block_after_timestamp(now_time.timestamp(), True)
+    week_ago = closest_block_after_timestamp((now_time - timedelta(days=7)).timestamp(), True)
+    month_ago = closest_block_after_timestamp((now_time - timedelta(days=31)).timestamp(), True)
     return ApySamples(now, week_ago, month_ago)

--- a/yearn/prices/uniswap/uniswap.py
+++ b/yearn/prices/uniswap/uniswap.py
@@ -37,8 +37,10 @@ class UniswapVersionMultiplexer:
         token = convert.to_address(token)
 
         # NOTE Following our usual logic with WETH is a big no-no. Too many calls.
-        if token in [constants.weth, WRAPPED_GAS_COIN] and block <= contract_creation_block(chainlink.get_feed(token)):
-            return self._early_exit_for_gas_coin(token, block=block)
+        if token in [constants.weth, WRAPPED_GAS_COIN]:
+            # try to use chainlink if it's available on the current network
+            if chainlink and block <= contract_creation_block(chainlink.get_feed(token)):
+                return self._early_exit_for_gas_coin(token, block=block)
 
         deepest_uniswap = self.deepest_uniswap(token, block)
         if deepest_uniswap:


### PR DESCRIPTION
can be tested with:
`DEBUG=true make apy network=arbitrum`