### PR TITLE
Feat/revenues weekly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,19 @@ logs: get-network-name
 .SILENT:
 up: get-network-name
 	$(eval commands = $(if $(commands),$(commands),$(exporter_scripts)))
+	$(eval with_logs = $(if $(with_logs),$(with_logs),true))
 	if [ "$(NETWORK)" != "" ]; then
-		make single-network network=$(NETWORK) commands="$(commands)" logs
+		if [ "$(with_logs)" == "true" ]; then
+			make single-network network=$(NETWORK) commands="$(commands)" logs
+		else
+			make single-network network=$(NETWORK) commands="$(commands)"
+		fi
 	else
-		make all-networks commands="$(commands)" logs
+		if [ "$(with_logs)" == "true" ]; then
+			make all-networks commands="$(commands)" logs
+		else
+			make all-networks commands="$(commands)"
+		fi
 	fi
 
 console: get-network-name
@@ -211,7 +220,7 @@ apy: up
 
 # revenue scripts
 revenues:
-	make up network=eth commands=revenues
+	make up network=eth commands=revenues with_logs=false
 
 # partners scripts
 partners-eth:

--- a/scripts/revenues.py
+++ b/scripts/revenues.py
@@ -5,7 +5,7 @@ import boto3
 import sentry_sdk
 import logging
 import yearn
-from datetime import datetime
+from datetime import datetime, timedelta
 
 sentry_sdk.set_tag('script','revenues')
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ def main():
     debug = os.getenv("DEBUG", None)
 
     today = datetime.today()
-    from_str = os.getenv("REVENUES_FROM", today.replace(day=1).strftime('%Y-%m-%d'))
+    from_str = os.getenv("REVENUES_FROM", (today-timedelta(days=7)).strftime('%Y-%m-%d'))
     to_str   = os.getenv("REVENUES_TO", today.strftime('%Y-%m-%d'))
     file_name = f"revenues_{from_str}_{to_str}.csv"
     file_path = f"/tmp/{file_name}"

--- a/yearn/treasury/treasury.py
+++ b/yearn/treasury/treasury.py
@@ -69,6 +69,7 @@ SKIP_LOGS = {
         '0x9D79d5B61De59D882ce90125b18F74af650acB93', # NBST token with erroneous price
         # Other:
         '0x1BA4b447d0dF64DA64024e5Ec47dA94458C1e97f', # Hegic Option Token from strategist testing, expired and worthless
+        '0xeaaa790591c646b0436f02f63e8Ca56209FEDE4E', # DHR D-Horse token
     ],
     Network.Fantom: [
         "0x630277E37fd2Ddf81e4683f3692dD817aa6225Cb", # 8bitcats


### PR DESCRIPTION
Prior to this we exported the revenues from 1st of month until the current date.
This causes us to miss on some data at the end of the month if the current date is *not* the end of the month.

In this PR we always export on a weekly basis which also accounts for overlapping ranges between two months.