### PR TITLE
fix: read partner tracker for arbi from interface abi.

### DIFF
--- a/interfaces/yearn/partner_tracker_arbitrum.json
+++ b/interfaces/yearn/partner_tracker_arbitrum.json
@@ -1,0 +1,71 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "partnerId",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountAdded",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalDeposited",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReferredBalanceIncreased",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "vault", "type": "address" },
+      { "internalType": "address", "name": "partnerId", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "deposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "vault", "type": "address" },
+      { "internalType": "address", "name": "partnerId", "type": "address" }
+    ],
+    "name": "deposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "referredBalance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/yearn/__init__.py
+++ b/yearn/__init__.py
@@ -1,3 +1,4 @@
+import json
 from brownie import network, chain, Contract
 from yearn.networks import Network
 from yearn.logs import setup_logging
@@ -13,3 +14,11 @@ if network.is_connected():
     if chain.id == Network.Mainnet:
         # compile LINK contract locally for mainnet with latest solc because the etherscan abi crashes event parsing
         Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
+
+    elif chain.id == Network.Arbitrum:
+        # workaround for issues loading the partner tracker contract on arbitrum
+        Contract.from_abi(
+            name='YearnPartnerTracker',
+            address='0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7',
+            abi=json.load(open('interfaces/yearn/partner_tracker_arbitrum.json'))
+        )

--- a/yearn/partners/delegated.py
+++ b/yearn/partners/delegated.py
@@ -1,11 +1,21 @@
+import json
 from collections import defaultdict
 from math import ceil
 
-from brownie import chain
+from brownie import Contract, chain
 from toolz import last
 from yearn.events import decode_logs, get_logs_asap
 from yearn.networks import Network
 from yearn.utils import contract
+
+# workaround for issues loading the partner tracker contract on arbitrum
+if chain.id == Network.Arbitrum:
+    # cache it for the next calls
+    Contract.from_abi(
+        name='YearnPartnerTracker',
+        address='0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7',
+        abi=json.load(open('interfaces/yearn/partner_tracker_arbitrum.json'))
+    )
 
 YEARN_PARTNER_TRACKER = contract({
     Network.Mainnet: "0x8ee392a4787397126C163Cb9844d7c447da419D8",

--- a/yearn/partners/delegated.py
+++ b/yearn/partners/delegated.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 from math import ceil
 
@@ -7,15 +6,6 @@ from toolz import last
 from yearn.events import decode_logs, get_logs_asap
 from yearn.networks import Network
 from yearn.utils import contract
-
-# workaround for issues loading the partner tracker contract on arbitrum
-if chain.id == Network.Arbitrum:
-    # cache it for the next calls
-    Contract.from_abi(
-        name='YearnPartnerTracker',
-        address='0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7',
-        abi=json.load(open('interfaces/yearn/partner_tracker_arbitrum.json'))
-    )
 
 YEARN_PARTNER_TRACKER = contract({
     Network.Mainnet: "0x8ee392a4787397126C163Cb9844d7c447da419D8",


### PR DESCRIPTION
frist, remove the middleware cache:
```
docker volume rm arbitrum_cache
```
start a brownie console:
```
make console network=arbitrum
```
verify the contract can be loaded
```
>>> from yearn.partners import delegated
>>> Contract('0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7')
<YearnPartnerTracker Contract '0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7'>
```