### PR TITLE
Fixes for renBTC (mainnet) and event parsing for vaults/strategies

### DIFF
--- a/yearn/prices/magic.py
+++ b/yearn/prices/magic.py
@@ -110,6 +110,9 @@ def find_price(
         # no liquidity for curve pool (yvecrv-f) -> return 0
         elif token == "0x7E46fd8a30869aa9ed55af031067Df666EfE87da" and block < 14987514:
             return 0
+        # no continuous price data before 2020-10-10
+        elif token == "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D" and block < 11024342:
+            return 0
 
     markets = [
         chainlink,

--- a/yearn/v2/strategies.py
+++ b/yearn/v2/strategies.py
@@ -1,10 +1,8 @@
 import logging
 import threading
 import time
-import inflection
 from typing import List
 
-from collections import OrderedDict
 from eth_utils import encode_hex, event_abi_to_log_topic
 from yearn.decorators import sentry_catch_all, wait_or_exit_after
 from yearn.events import create_filter, decode_logs
@@ -90,8 +88,6 @@ class Strategy:
 
     def process_events(self, events):
         for event in events:
-            # hack to make camels to snakes
-            event._ordered = [OrderedDict({inflection.underscore(k): v for k, v in od.items()}) for od in event._ordered]
             if event.name == "Harvested":
                 block = event.block_number
                 logger.debug("%s harvested on %d", self.name, block)

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -2,10 +2,8 @@ import logging
 import re
 import threading
 import time
-import inflection
 from typing import Dict, List
 
-from collections import OrderedDict
 from brownie import chain
 from eth_utils import encode_hex, event_abi_to_log_topic
 from joblib import Parallel, delayed
@@ -164,8 +162,6 @@ class Vault:
 
     def process_events(self, events):
         for event in events:
-            # hack to make camels to snakes
-            event._ordered = [OrderedDict({inflection.underscore(k): v for k, v in od.items()}) for od in event._ordered]
             # some issues during the migration of this strat prevented it from being verified so we skip it here...
             if chain.id == Network.Optimism:
                 failed_migration = False


### PR DESCRIPTION
this pr fixes:
- renBTC prices not being stable before 2020-10-10
- broken event parsing for vaults and strategies

deployed to staging with a full historical rebuild