### PR TITLE
fix: regex to create a NAME for running multiple command args 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,7 +50,7 @@ export SENTRY_RELEASE=$(git rev-parse --short HEAD)
 IFS=',' read -r -a commands <<< "$COMMANDS"
 #TODO add --detach
 for CMD in "${commands[@]}"; do
-  NAME=$(echo $CMD | sed -e 's/\//_/g')
+  NAME=$(echo $CMD | sed -e 's/[/ ]/_/g')
   # TODO handle multiple containers with the same name more gracefully
   CONTAINER_NAME=${NETWORK}_${NAME}_1
   docker rm -f $CONTAINER_NAME 2> /dev/null || true


### PR DESCRIPTION
(e.g. `brownie run s3 with_monitoring`)

Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
