### PR TITLE
fix: closest_block_after_timestamp signature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pytest-bdd>=5.0.0
 eth_retry>=0.1.1
 eth-hash[pysha3]
 python-telegram-bot>=13.14
-ypricemagic>=1.10.2
+ypricemagic>=1.10.4


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Added `wait_for_block_if_needed` kwarg to closest_block_after_timestamp in ypm, and updated the dependency here.

### How I did it:
^^

### How to verify it:
Run the debug apy script

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
