### PR TITLE
fix: cache_token defaults for Arbi and Opti

### DIFF
--- a/yearn/outputs/postgres/utils.py
+++ b/yearn/outputs/postgres/utils.py
@@ -44,6 +44,8 @@ def cache_token(address: str) -> Token:
             symbol, name = {
                 Network.Mainnet: ("ETH","Ethereum"),
                 Network.Fantom: ("FTM","Fantom"),
+                Network.Arbitrum: ("ETH", "Ethereum"),
+                Network.Optimism: ("ETH", "Ethereum"),
             }[chain.id]
             decimals = 18
         else:


### PR DESCRIPTION
Related issue # (if applicable):
https://sentry.yearn.vision/organizations/yearn/issues/7626/?environment=production&project=2&query=is%3Aunresolved

### What I did:
Added gas token name and symbol for Arbi and Opti

### How I did it:
its just a key lookup so I added the vals

### How to verify it:
check the chain bro

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
