### PR TITLE
fix: curve pool underlying prices

### DIFF
--- a/scripts/exporters/treasury_transactions.py
+++ b/scripts/exporters/treasury_transactions.py
@@ -37,7 +37,7 @@ BATCH_SIZE = {
     Network.Mainnet: 25_000,
     Network.Fantom: 2_000_000,
     Network.Gnosis: 2_000_000,
-    Network.Arbitrum: 1_000_000,
+    Network.Arbitrum: 2_000_000,
     Network.Optimism: 1_000_000,
 }[chain.id]
 

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -402,25 +402,6 @@ class CurveRegistry(metaclass=Singleton):
             return 0
         return tvl / supply
 
-        # approximate by using the most common base token we find
-        coins = self.get_underlying_coins(pool)
-        try:
-            coin = (set(coins) & BASIC_TOKENS).pop()
-        except KeyError:
-            coin = coins[0]
-
-        try:
-            virtual_price = self.get_virtual_price(pool, block)
-            if virtual_price:
-                return virtual_price * magic.get_price(coin, block)
-            return sum([balance * magic.get_price(coin, block) for coin, balance in self.get_balances(pool, block).items()])
-        except ValueError as e:
-            logger.warn(f'ValueError: {str(e)}')
-            if 'No data was returned' in str(e):
-                return None
-            else:
-                raise
-    
     def get_coin_price(self, token: AddressOrContract, block: Optional[Block] = None) -> Optional[float]:
 
         # Get the pool

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -424,8 +424,11 @@ class CurveRegistry(metaclass=Singleton):
     def get_coin_price(self, token: AddressOrContract, block: Optional[Block] = None) -> Optional[float]:
 
         # Get the pool
-        if len(self.coin_to_pools[token]) == 1:
-            pool = self.coin_to_pools[token][0]
+        if token in self.coin_to_pools and len(self.coin_to_pools[token]) > 0:
+            pools = self.coin_to_pools[token]
+            if len(pools) > 1:
+                logger.warn(f'Found >1 pools for token {token}: {pools}, picking first pool: {pools[0]}')
+            pool = pools[0]
         else:
             # TODO: handle this sitch if necessary
             return

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -419,8 +419,8 @@ class CurveRegistry(metaclass=Singleton):
                     if str(pool_bals).startswith("could not fetch balances"):
                         continue
                     raise pool_bals
-                for token, bal in pool_bals.items():
-                    if token == token_in and bal > deepest_bal:
+                for _token, bal in pool_bals.items():
+                    if _token == token and bal > deepest_bal:
                         deepest_pool = pool
                         deepest_bal = bal
             pool = deepest_pool


### PR DESCRIPTION
Related issue # (if applicable):
This PR fixes the pricing of the yCRV token [0xFCc5c47bE19d06BF83eB04298b026F81069ff65b](https://etherscan.io/token/0xfcc5c47be19d06bf83eb04298b026f81069ff65b)
### What I did:
I've fixed the bug where we couldn't price the underlying token of a factory pool.

### How I did it:
I've modified the pricing logic inside `curve.get_coin_price` so that we allow the token to be in >1 pools. If so, we determine the pool with the deepest liquidity and use it.

### How to verify it:
I've deployed this to yv-staging, open to verification.

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
