### PR TITLE
fix: recursion error

### DIFF
--- a/tests/yearn/treasury/test_buckets.py
+++ b/tests/yearn/treasury/test_buckets.py
@@ -1,0 +1,6 @@
+
+from yearn.treasury.buckets import get_token_bucket
+
+def test_get_token_bucket():
+    new_bal_pool = "0x2F4eb100552ef93840d5aDC30560E5513DFfFACb"
+    assert get_token_bucket(new_bal_pool)

--- a/yearn/treasury/buckets.py
+++ b/yearn/treasury/buckets.py
@@ -55,7 +55,7 @@ def _unwrap_token(token) -> str:
         # should only be YLA # TODO figure this out
         bal_for_pool = bal.selector.get_balancer_for_pool(token)
         pool_tokens = set(
-            str(_unwrap_token(coin)) for coin in bal_for_pool.get_tokens(token)
+            str(_unwrap_token(coin)) for coin in bal_for_pool.get_tokens(token) if coin != token
         )
         return _pool_bucket(pool_tokens)
     if aave and token in aave:


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Some newer balancer pools reference itself in the list of underlying tokens. We simply ignore that specific underlying in our get_token_bucket code if the address matches the pool address

### How I did it:
See above

### How to verify it:
Call get_token_bucket on 0x2F4eb100552ef93840d5aDC30560E5513DFfFACb on mainnet

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers (n/a)
- [x] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
