### PR TITLE
feat: include a new object with block nums for a few APY sample points

### DIFF
--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -220,7 +220,7 @@ def main():
 
 
 def _export(data, file_name, s3_path):
-    print(json.dumps(data))
+    print(json.dumps(data, indent=4))
 
     with open(file_name, "w+") as f:
         json.dump(data, f)

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("yearn.apy")
 def wrap_vault(
     vault: Union[VaultV1, VaultV2], samples: ApySamples, aliases: dict, icon_url: str, assets_metadata: dict
 ) -> dict:
-    apy_error = Apy("error", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0), ApyBlocks(chain.height, 0, 0, 0))
+    apy_error = Apy("error", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0), ApyBlocks(samples.now, 0, 0, 0))
     try:
         apy = vault.apy(samples)
     except ValueError as error:

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -15,7 +15,7 @@ import requests
 import sentry_sdk
 from brownie import chain, web3, Contract
 from brownie.exceptions import BrownieEnvironmentWarning
-from yearn.apy import Apy, ApyFees, ApyPoints, ApySamples, get_samples
+from yearn.apy import Apy, ApyBlocks, ApyFees, ApyPoints, ApySamples, get_samples
 from yearn.exceptions import EmptyS3Export, PriceError
 from yearn.graphite import send_metric
 from yearn.networks import Network
@@ -39,7 +39,7 @@ logger = logging.getLogger("yearn.apy")
 def wrap_vault(
     vault: Union[VaultV1, VaultV2], samples: ApySamples, aliases: dict, icon_url: str, assets_metadata: dict
 ) -> dict:
-    apy_error = Apy("error", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0))
+    apy_error = Apy("error", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0), ApyBlocks(chain.height, 0, 0, 0))
     try:
         apy = vault.apy(samples)
     except ValueError as error:

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -271,6 +271,10 @@ def _get_export_paths(suffix):
 
 
 def with_monitoring():
+    if os.getenv("DEBUG", None):
+        main()
+        return
+
     from telegram.ext import Updater
 
     private_group = os.environ.get('TG_YFIREBOT_GROUP_INTERNAL')

--- a/yearn/apy/__init__.py
+++ b/yearn/apy/__init__.py
@@ -3,4 +3,4 @@ from yearn.apy import v2
 
 from yearn.apy.curve import simple as curve
 
-from yearn.apy.common import ApySamples, Apy, ApyError, get_samples, ApyFees, ApyPoints
+from yearn.apy.common import ApySamples, Apy, ApyBlocks, ApyError, get_samples, ApyFees, ApyPoints

--- a/yearn/apy/common.py
+++ b/yearn/apy/common.py
@@ -24,6 +24,12 @@ class ApyFees:
     keep_crv: Optional[float] = None
     cvx_keep_crv: Optional[float] = None
 
+@dataclass
+class ApyBlocks:
+    now: int
+    week_ago: int
+    month_ago: int
+    inception: int
 
 @dataclass
 class ApyPoints:
@@ -39,6 +45,7 @@ class Apy:
     net_apy: float
     fees: ApyFees
     points: Optional[ApyPoints] = None
+    blocks: Optional[ApyBlocks] = None
     composite: Optional[Dict[str, float]] = None
 
 

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -1,4 +1,3 @@
-from brownie import chain
 from yearn.utils import contract_creation_block
 
 from yearn.apy.common import (
@@ -77,6 +76,6 @@ def simple(vault, samples: ApySamples) -> Apy:
     gross_apr = apr_after_fees / (1 - performance)
     
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
-    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
+    blocks = ApyBlocks(samples.now, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, withdrawal=withdrawal)
     return Apy("v1:simple", gross_apr, net_apy, fees, points=points, blocks=blocks)

--- a/yearn/apy/v1.py
+++ b/yearn/apy/v1.py
@@ -1,7 +1,9 @@
+from brownie import chain
 from yearn.utils import contract_creation_block
 
 from yearn.apy.common import (
     Apy,
+    ApyBlocks,
     ApyError,
     ApyPoints,
     ApyFees,
@@ -75,5 +77,6 @@ def simple(vault, samples: ApySamples) -> Apy:
     gross_apr = apr_after_fees / (1 - performance)
     
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
+    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, withdrawal=withdrawal)
-    return Apy("v1:simple", gross_apr, net_apy, fees, points=points)
+    return Apy("v1:simple", gross_apr, net_apy, fees, points=points, blocks=blocks)

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -7,6 +7,7 @@ from semantic_version.base import Version
 
 from yearn.apy.common import (
     Apy,
+    ApyBlocks,
     ApyError,
     ApyPoints,
     ApyFees,
@@ -117,8 +118,9 @@ def simple(vault, samples: ApySamples) -> Apy:
         net_apy = 0
 
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
+    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, management=management)
-    return Apy("v2:simple", gross_apr, net_apy, fees, points=points)
+    return Apy("v2:simple", gross_apr, net_apy, fees, points=points, blocks=blocks)
 
 
 def average(vault, samples: ApySamples) -> Apy:
@@ -218,5 +220,6 @@ def average(vault, samples: ApySamples) -> Apy:
         net_apy = 0
 
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
+    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, management=management)
-    return Apy("v2:averaged", gross_apr, net_apy, fees, points=points)
+    return Apy("v2:averaged", gross_apr, net_apy, fees, points=points, blocks=blocks)

--- a/yearn/apy/v2.py
+++ b/yearn/apy/v2.py
@@ -118,7 +118,7 @@ def simple(vault, samples: ApySamples) -> Apy:
         net_apy = 0
 
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
-    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
+    blocks = ApyBlocks(samples.now, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, management=management)
     return Apy("v2:simple", gross_apr, net_apy, fees, points=points, blocks=blocks)
 
@@ -220,6 +220,6 @@ def average(vault, samples: ApySamples) -> Apy:
         net_apy = 0
 
     points = ApyPoints(week_ago_apy, month_ago_apy, inception_apy)
-    blocks = ApyBlocks(chain.height, samples.week_ago, samples.month_ago, inception_block)
+    blocks = ApyBlocks(samples.now, samples.week_ago, samples.month_ago, inception_block)
     fees = ApyFees(performance=performance, management=management)
     return Apy("v2:averaged", gross_apr, net_apy, fees, points=points, blocks=blocks)

--- a/yearn/special.py
+++ b/yearn/special.py
@@ -4,8 +4,9 @@ from time import time
 import eth_retry
 import requests
 from joblib import Parallel, delayed
+from brownie import chain
 
-from yearn.apy.common import Apy, ApyFees, ApyPoints, ApySamples
+from yearn.apy.common import Apy, ApyBlocks, ApyFees, ApyPoints, ApySamples
 from yearn.common import Tvl
 from yearn.exceptions import PriceError
 from yearn.prices import magic
@@ -38,7 +39,9 @@ class YveCRVJar(metaclass = Singleton):
         yvboost_eth_pool  = [pool for pool in data if pool["identifier"] == "yvboost-eth"][0]
         apy = yvboost_eth_pool["apy"]  / 100.
         points = ApyPoints(apy, apy, apy)
-        return Apy("yvecrv-jar", apy, apy, ApyFees(), points=points)
+        height = chain.height
+        blocks = ApyBlocks(height, height, height, height)
+        return Apy("yvecrv-jar", apy, apy, ApyFees(), points=points, blocks=blocks)
 
     @eth_retry.auto_retry
     def tvl(self, block=None) -> Tvl:

--- a/yearn/special.py
+++ b/yearn/special.py
@@ -4,7 +4,6 @@ from time import time
 import eth_retry
 import requests
 from joblib import Parallel, delayed
-from brownie import chain
 
 from yearn.apy.common import Apy, ApyBlocks, ApyFees, ApyPoints, ApySamples
 from yearn.common import Tvl
@@ -39,9 +38,9 @@ class YveCRVJar(metaclass = Singleton):
         yvboost_eth_pool  = [pool for pool in data if pool["identifier"] == "yvboost-eth"][0]
         apy = yvboost_eth_pool["apy"]  / 100.
         points = ApyPoints(apy, apy, apy)
-        height = chain.height
+        block = samples.now
         inception_block = contract_creation_block(str(self.vault))
-        blocks = ApyBlocks(height, height, height, inception_block)
+        blocks = ApyBlocks(block, block, block, inception_block)
         return Apy("yvecrv-jar", apy, apy, ApyFees(), points=points, blocks=blocks)
 
     @eth_retry.auto_retry

--- a/yearn/special.py
+++ b/yearn/special.py
@@ -40,7 +40,8 @@ class YveCRVJar(metaclass = Singleton):
         apy = yvboost_eth_pool["apy"]  / 100.
         points = ApyPoints(apy, apy, apy)
         height = chain.height
-        blocks = ApyBlocks(height, height, height, height)
+        inception_block = contract_creation_block(str(self.vault))
+        blocks = ApyBlocks(height, height, height, inception_block)
         return Apy("yvecrv-jar", apy, apy, ApyFees(), points=points, blocks=blocks)
 
     @eth_retry.auto_retry


### PR DESCRIPTION
Related issue # (if applicable):
#435 
### What I did:
Added the block nums for `now`, `week_ago`, `month_ago`, `inception` to all apy calculators where we return also `ApyPoints`
For those where we don't return them like e.g. curve simple I didn't add this info yet because it's hard to determine which block it should be attributed to with the current calc logic.
### How I did it:

### How to verify it:
use a network which calculates quickly, e.g. ftm:
`DEBUG=true make apy network=ftm`

this produces the folllowing output for `yvWFTM`:

```
  {
    "inception": 16476356,
    "address": "0x0DEC85e74A92c52b7F708c4B10207D9560CEFaf0",
    "symbol": "yvWFTM",
    "name": "yvWFTM 0.4.3",
    ...
    },
    "apy": {
      ...
      "points": {
        "week_ago": 0.04074685763155883,
        "month_ago": 0.05048203850688959,
        "inception": 0.3656106019359633
      },
      "blocks": {
        "now": 52276022,
        "week_ago": 51955878,
        "month_ago": 50787760,
        "inception": 16478495
      },
      "composite": null
    }
```

For this vault, there's a small discrepancy between the two `inception` fields: the top-level one is the contract creation block, the inner one is the block that is the logical inception block as determined by the apy calculator. For v2 vaults, the inception marks the first time we have a report with allocated funds inside the vault so the two values will not be equal most of the times. For all other cases the two `inception` values should match and be the same.

### Checklist:
- [x] I have tested it locally and it works
- [x] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
