### PR TITLE
fix: locking python-telegram-bot to 13.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ sentry-sdk>=1.5.1
 pytest-bdd>=5.0.0
 eth_retry>=0.1.1
 eth-hash[pysha3]
-python-telegram-bot>=13.14
+python-telegram-bot==13.15
 ypricemagic>=1.10.8


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
