### PR TITLE
fix(treasury_transactions): decode bytes32 responses into strings

### DIFF
--- a/yearn/utils.py
+++ b/yearn/utils.py
@@ -8,6 +8,7 @@ from typing import List
 import eth_retry
 from brownie import Contract, chain, convert, interface, web3
 from brownie.network.contract import _fetch_from_explorer, _resolve_address
+from brownie.convert.datatypes import HexString
 
 from yearn.cache import memory
 from yearn.exceptions import ArchiveNodeRequired, NodeNotSynced
@@ -254,6 +255,12 @@ def chunks(lst, n):
     for i in range(0, len(lst), n):
         yield lst[i:i + n]
 
+def hex_to_string(h: HexString) -> str:
+    '''returns a string from a HexString'''
+    h = h.hex().rstrip("0")
+    if len(h) % 2 != 0:
+        h += "0"
+    return bytes.fromhex(h).decode("utf-8")
 
 def _squeeze(it):
     """ Reduce the contract size in RAM significantly. """


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
converting the HexString returned from the `name()` and `symbol()` functions from the MKR contract to normal strings that we can cache in our db.

https://etherscan.io/address/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2#readContract
### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
