### PR TITLE
fix: adding releaseRegistry to the list of known registries.

### DIFF
--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -67,7 +67,14 @@ class Registry(metaclass=Singleton):
         )
         events = decode_logs(get_logs_asap(str(resolver), topics))
         logger.info('loaded %d registry versions', len(events))
-        return [contract(event['newAddress'].hex()) for event in events]
+        registries = []
+        for event in events:
+            r = contract(event['newAddress'].hex())
+            registries.append(r)
+            if hasattr(r, 'releaseRegistry'):
+                rr = contract(r.releaseRegistry())
+                registries.append(rr)
+        return registries
 
     @property
     @wait_or_exit_before


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Adds the releaseRegistry which released `0.4.6` vaults. 

### How I did it:

### How to verify it:

```python
>>> from yearn.v2.registry import Registry
>>> r = Registry()
>>> r.releases
{
    '0.2.2': 0xBFa4D8AA6d8a379aBFe7793399D3DdaCC5bBECBB,
    '0.3.0': 0xe11ba472F74869176652C35D30dB89854b5ae84D,
    '0.3.1': 0xcB550A6D4C8e3517A939BC79d0c7093eb7cF56B5,
    '0.3.2': 0x986b4AFF588a109c09B50A03f42E4110E29D353F,
    '0.3.3': 0x662fBF2c1E4b04342EeBA6371ec1C7420042B86F,
    '0.3.4': 0x34fe2a45D8df28459d7705F37eD13d7aE4382009,
    '0.3.5': 0xA696a63cc78DfFa1a63E9E50587C197387FF6C7E,
    '0.4.0': 0xE7bf2905371cfEAEefE2D4c2C386b6B2a7e4270a,
    '0.4.1': 0x090c9d94817e78Cd975034B1be596bf432E1f6C6,
    '0.4.2': 0x671a912C10bba0CFA74Cfc2d6Fba9BA1ed9530B2,
    '0.4.3': 0x9C13e225AE007731caA49Fd17A41379ab1a489F4,
    '0.4.5': 0xfA6ebB3a62Dde486f87661D238B53BF6557d386A,
    '0.4.6': 0x910e6E8c29e1E02602863535295a531249965294
}
```
### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
