### PR TITLE
feat: merge proxy and implementation abis

### DIFF
--- a/yearn/utils.py
+++ b/yearn/utils.py
@@ -229,7 +229,11 @@ def _resolve_proxy(address):
             as_proxy_for = _resolve_address(implementation)
 
     if as_proxy_for:
-        name, abi, _ = _extract_abi_data(as_proxy_for)
+        name, implementation_abi, _ = _extract_abi_data(as_proxy_for)
+        # Here we merge the proxy ABI with the implementation ABI
+        # without doing this, we'd only get the implementation
+        # and would lack any valid methods/events from the proxy itself. 
+        abi += implementation_abi
     return Contract.from_abi(name, address, abi)
 
 


### PR DESCRIPTION
Without merging abis, we only get the implementation and lack any valid methods/events from the proxy itself.

Related issue # (if applicable):

### What I did: 
When querying a proxy, include the abi from both the proxy and the implemenation contract.

### How I did it: 
`abi = abi1 + abi2`

### How to verify it: 
Can test against this proxy `0xE95A203B1a91a908F9B9CE46459d101078c2c3cb` and it's implementation: `0xE95A203B1a91a908F9B9CE46459d101078c2c3cb`

### Checklist:
- [x] I have tested it locally and it works
- [x] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
