### PR TITLE
Fix curve api preview

### DIFF
--- a/scripts/curve_apy_previews.py
+++ b/scripts/curve_apy_previews.py
@@ -43,9 +43,18 @@ def _build_data(gauges):
 
         pool_coins = []
         for i in range(4):
-            coin_address = gauge.pool.coins(i)
+            try:
+                coin_address = gauge.pool.coins(i)
+            except ValueError as e:
+                # If the execution reverted, there is no coin with index i.
+                if str(e) == "execution reverted":
+                    continue
+                raise
+
+            # Sometimes the call returns the zero address instead of reverting. This means there is no coin with index i.
             if coin_address == ZERO_ADDRESS:
                 continue
+            
             try:
                 c = contract(coin_address)
                 pool_coins.append({"name": c.name(), "address": str(c)})

--- a/scripts/curve_apy_previews.py
+++ b/scripts/curve_apy_previews.py
@@ -102,8 +102,8 @@ def _get_gauges():
         url = f"{CURVE_API_URL}?blockChainId={chains[chain.id]}"
         response = requests.get(url)
         response_json = response.json()
-        if not response_json["success"]:
-            logger.error(response_json)
+            response = requests.get(url)
+            response_json = response.json()
             raise ValueError(f"Error fetching gauges from {url}")
 
         return response_json["data"]

--- a/scripts/curve_apy_previews.py
+++ b/scripts/curve_apy_previews.py
@@ -1,19 +1,21 @@
-import requests
 import dataclasses
-import logging
 import json
-import re
+import logging
 import os
-import boto3
+import re
 import shutil
+from time import sleep, time
+
+import boto3
+import requests
 import sentry_sdk
-from time import time
 from brownie import chain
-from yearn.apy.curve.simple import Gauge, calculate_simple
+
 from yearn.apy import Apy, ApyFees, ApyPoints, ApySamples, get_samples
+from yearn.apy.curve.simple import Gauge, calculate_simple
 from yearn.exceptions import EmptyS3Export, PriceError
-from yearn.utils import contract
 from yearn.networks import Network
+from yearn.utils import contract
 
 logger = logging.getLogger(__name__)
 sentry_sdk.set_tag('script','curve_apy_previews')
@@ -100,13 +102,19 @@ def _extract_gauge(v):
 def _get_gauges():
     if chain.id in chains:
         url = f"{CURVE_API_URL}?blockChainId={chains[chain.id]}"
-        response = requests.get(url)
-        response_json = response.json()
+        attempts = 0
+        while attempts < 5:
             response = requests.get(url)
             response_json = response.json()
-            raise ValueError(f"Error fetching gauges from {url}")
+            if response_json["success"]:
+                return response_json["data"]
+            logger.error(response_json)
+            if attempts >= 5:
+                raise ValueError(f"Error fetching gauges from {url}")
+            attempts += 1
+            sleep(.1)
 
-        return response_json["data"]
+        
     else:
         raise ValueError(f"can't get curve gauges for unsupported network: {chain.id}")
 

--- a/scripts/curve_apy_previews.py
+++ b/scripts/curve_apy_previews.py
@@ -9,7 +9,7 @@ from time import sleep, time
 import boto3
 import requests
 import sentry_sdk
-from brownie import chain
+from brownie import ZERO_ADDRESS, chain
 
 from yearn.apy import Apy, ApyFees, ApyPoints, ApySamples, get_samples
 from yearn.apy.curve.simple import Gauge, calculate_simple
@@ -42,8 +42,10 @@ def _build_data(gauges):
             continue
 
         pool_coins = []
-        for i in range(2):
+        for i in range(4):
             coin_address = gauge.pool.coins(i)
+            if coin_address == ZERO_ADDRESS:
+                continue
             try:
                 c = contract(coin_address)
                 pool_coins.append({"name": c.name(), "address": str(c)})


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Fixed an issue that limited display of pool tokens to 2 tokens
Fixed an intermittent issue with failed calls to Curve's API

### How I did it:
For the former, I increased the int in a range() call
For the latter, I implemented a retry loop.

### How to verify it:
run curve_apy_preview

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
