### PR TITLE
fix: don't try to handle naked ETH as a contract

### DIFF
--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -15,6 +15,7 @@ Metapool Factory (id 3)
 import logging
 import threading
 import time
+from y.constants import EEE_ADDRESS
 from collections import defaultdict
 from enum import IntEnum
 from typing import Dict, List, Optional
@@ -449,8 +450,12 @@ class CurveRegistry(metaclass=Singleton):
         except:
             return None
         
-        token_out = contract(coins[token_out_ix])
-        amount_out = dy / 10 ** token_out.decimals()
+        if coins[token_out_ix] == EEE_ADDRESS:
+            token_out = EEE_ADDRESS
+            amount_out = dy / 10 ** 18
+        else:
+            token_out = contract(coins[token_out_ix])
+            amount_out = dy / 10 ** token_out.decimals()
         try:
             return amount_out * magic.get_price(token_out, block = block)
         except PriceError:


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Fixed a bug when calculating the curve pool price and one of the pool coins is naked ETH (thanks @BobTheBuidler )

### How I did it:

### How to verify it:

`magic.get_price('0x9848482da3Ee3076165ce6497eDA906E66bB85C5')`

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
