### PR TITLE
fix: sETH pricing on optimism

### DIFF
--- a/tests/prices/test_synthetix.py
+++ b/tests/prices/test_synthetix.py
@@ -1,5 +1,8 @@
 import pytest
-from tests.fixtures.decorators import synthetix_chains_only
+from brownie import chain
+from y.networks import Network
+
+from tests.fixtures.decorators import mainnet_only, synthetix_chains_only
 from yearn.prices.synthetix import synthetix
 from yearn.utils import contract
 
@@ -10,10 +13,13 @@ if synthetix:
 
 @synthetix_chains_only
 def test_get_synths():
-    assert len(synthetix.synths) >= 10
+    assert len(synthetix.synths) >= {
+        Network.Mainnet: 10,
+        Network.Optimism: 5,
+    }[chain.id]
 
 
-@synthetix_chains_only
+@mainnet_only
 def test_synthetix_detection():
     sLINK = '0xbBC455cb4F1B9e4bFC4B73970d360c8f032EfEE6'
     assert sLINK in synthetix

--- a/yearn/prices/synthetix.py
+++ b/yearn/prices/synthetix.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 addresses = {
     Network.Mainnet: '0x823bE81bbF96BEc0e25CA13170F5AaCb5B79ba83',
+    Network.Optimism: '0x95A6a3f44a70172E7d50a9e28c85Dfd712756B8C',
 }
 
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Added the Synthetix ExchangeRate contract address for optimism

### How I did it:
Simple addition to a mapping

### How to verify it:
Try to price sETH on Opti

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [x] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
