### PR TITLE
feat: disable gnosis exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 #######################################
 # specify all supported networks here #
 #######################################
-supported_networks := ethereum fantom arbitrum optimism gnosis
+supported_networks := ethereum fantom arbitrum optimism
 
 ###############################################
 # specify all supported exporter scripts here #

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ The dockerized exporter is controlled via `make up` command which is invoked via
 It is possible to specify multiple Makefile args that control which exporters are started on which network.
 The available args to control the startup sequence of containers are the following:
 
-- `network`: one of `ethereum`, `fantom`, `arbitrum`, `optimism`, `gnosis`, see `make list-networks`
+- `network`: one of `ethereum`, `fantom`, `arbitrum`, `optimism`, see `make list-networks`
 - `commands`: a list of strings delimited with comma pointing to brownie scripts in `./scripts/` e.g. `exporters/partners,exporters/vaults`, see `make list-commands`
 - `filter`: used for `make logs` and `make down` to match the container name substring.
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Disabled `gnosis` exporters when invoking `make up`

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
