### PR TITLE
fix(optimism): update staking rewards registry address

### DIFF
--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -57,7 +57,7 @@ class Registry(metaclass=Singleton):
             return [
                 contract('0x79286Dd38C9017E5423073bAc11F53357Fc5C128'),
                 contract('0x81291ceb9bB265185A9D07b91B5b50Df94f005BF'),
-                contract('0xB54d1833ACA99B0E50dfCC7F55A9165c6805BB9f'), # StakingRewardsRegistry
+                contract('0x8ED9F6343f057870F1DeF47AaE7CD88dfAA049A8'), # StakingRewardsRegistry
             ]
         else:
             raise UnsupportedNetwork('yearn v2 is not available on this network')


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
- Update the staking rewards registry address to latest

### How I did it:
- Replaced current address where its being used

### How to verify it:
- Using https://github.com/yearn/yearn-strategies/issues/475#issuecomment-1495139236

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug
