### PR TITLE
fix: batch call err handling

### DIFF
--- a/yearn/multicall2.py
+++ b/yearn/multicall2.py
@@ -139,10 +139,14 @@ def batch_call(calls):
     responses = [requests.post(web3.provider.endpoint_uri, json=jsonrpc_batch).json() for jsonrpc_batch in chunks]
 
     for response in responses:
-        # A successful response will be a list
-        if isinstance(response, dict) and 'result' in response and isinstance(response['result'], dict) and 'message' in response['result']:
-            raise ValueError(response['result']['message'])
-            
+        # A successful response will be a list, a dict means an err.
+        if isinstance(response, dict):
+            if 'result' in response and isinstance(response['result'], dict) and 'message' in response['result']:
+                raise ValueError(response['result']['message'])
+            elif 'error' in response and isinstance(response['error'], dict) and 'message' in response['error']:
+                raise ValueError(response['error']['message'])
+            raise NotImplementedError(f"Need to code err handling for {response}")
+        
         for call_response in response:
             if 'error' in call_response:
                 raise ValueError(call_response['error']['message'])


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Fixed the err handling code for batch_call

### How I did it:
This error took a different form than previous ones, so I updated the handler code to account for both situations.

### How to verify it:
You can run the partner script on a node with a limited jsonrpc batch size and see that the batch size error is correctly raised.

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
