### PR TITLE
fix: early exit if staking pool still has totalSupply == 0

### DIFF
--- a/yearn/apy/staking_rewards.py
+++ b/yearn/apy/staking_rewards.py
@@ -20,6 +20,9 @@ def get_staking_rewards_apr(vault, samples: ApySamples):
     if staking_pool.periodFinish() < now:
         return 0
 
+    if staking_pool.totalSupply() == 0:
+        return 0
+
     rewards_vault = vault.registry._vaults[staking_pool.rewardsToken()]
     per_staking_token_rate = (staking_pool.rewardRate() / 10**rewards_vault.vault.decimals()) / (staking_pool.totalSupply() / 10**vault.vault.decimals())
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
