### PR TITLE
fix: partners

### DIFF
--- a/yearn/partners/snapshot.py
+++ b/yearn/partners/snapshot.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from decimal import Decimal
@@ -12,7 +13,6 @@ import pandas as pd
 from async_lru import alru_cache
 from async_property import async_cached_property
 from brownie import chain, convert, multicall, web3
-from dank_mids.executor import PruningThreadPoolExecutor
 from pandas import DataFrame
 from pandas.core.tools.datetimes import DatetimeScalar
 from pony.orm import OperationalError, commit, db_session
@@ -196,7 +196,7 @@ class WildcardWrapper:
             {'receiver': wrappers},
         )
         addresses = [str(vault.vault) for vault in registry.vaults]
-        from_block = min(PruningThreadPoolExecutor().map(contract_creation_block, addresses))
+        from_block = min(ThreadPoolExecutor(8).map(contract_creation_block, addresses))
 
         # wrapper -> {vaults}
         deposits = defaultdict(set)


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Swapped out AsyncThreadPoolExecutor with concurrent.futures.ThreadPoolExecutor since we actually do want to use it in sync context here
### How I did it:
n/a

### How to verify it:
`make partners`

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
