### PR TITLE
fix: pin dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pytest-bdd>=5.0.0
 dank_mids==4.20.50.dev181
 eth_retry>=0.1.18
 eth-hash[pysha3]
-ez-a-sync>=0.5.5.dev1
+ez-a-sync==0.6.0
 python-telegram-bot==13.15
 ypricemagic>=2.6.0
 git+https://www.github.com/BobTheBuidler/eth-portfolio@08cd54e399ab72f620b3ab7971ee36e36587b705


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
pinned ez-a-sync to 0.6.0

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
