### PR TITLE
chore: push stable release of ez-a-sync

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,10 @@ pony>=0.7.16
 sqlalchemy>=1.4.41
 sentry-sdk==1.27.1
 pytest-bdd>=5.0.0
-dank_mids==4.20.50.dev254
+dank_mids==4.20.50.dev256
 eth_retry>=0.1.18
 eth-hash[pysha3]
-ez-a-sync==0.6.1.dev10
+ez-a-sync==0.6.1
 python-telegram-bot==13.15
 ypricemagic==2.8.3.dev3
 git+https://www.github.com/BobTheBuidler/eth-portfolio@22bd89a64b8d9d0ae66e390cc16ebb5ff694ed8d


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
I pushed a stable release of ez-a-sync so we don't have to keep the prerelease pinned

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
