### PR TITLE
fix: ApyError string formation when Exc args are not strings

### DIFF
--- a/scripts/curve_apy_previews.py
+++ b/scripts/curve_apy_previews.py
@@ -72,7 +72,7 @@ def _build_data(gauges):
             else:
                 apy = Apy("zero_weight", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0))
         except Exception as error:
-            apy_error.error_reason = ":".join(error.args)
+            apy_error.error_reason = ":".join(str(arg) for arg in error.args)
             logger.error(error)
             logger.error(gauge)
             apy = apy_error

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -53,11 +53,11 @@ async def wrap_vault(
     try:
         apy, tvl = await asyncio.gather(vault.apy(samples), vault.tvl())
     except ValueError as error:
-        apy_error.error_reason = ":".join(error.args)
+        apy_error.error_reason = ":".join(str(arg) for arg in error.args)
         logger.error(error)
         apy = apy_error
     except yPriceMagicError as error:
-        apy_error.error_reason = ":".join(error.args)
+        apy_error.error_reason = ":".join(str(arg) for arg in error.args)
         logger.error(error)
         apy = apy_error
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
