### PR TITLE
fix: build step bug due to pyyaml cython interaction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN apt-get update && \
     apt-get install -y gcc git
 ADD requirements.txt  ./
 RUN mkdir -p /install
+# NOTE: We have to do this to force pyyaml to install
+RUN pip3 install --prefix=/install "Cython<3.0" "pyyaml==5.4.1" --no-build-isolation
 RUN pip3 install --prefix=/install -r requirements.txt
 
 FROM python:3.10.12-slim


### PR DESCRIPTION
Related issue # (if applicable):
### Context:
https://github.com/yaml/pyyaml/issues/601

### What I did:
Resolved a conflict between cython and the pyyaml version required by brownie

### How I did it:
Added a build step to the dockerfile

### How to verify it:
make build

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
