### PR TITLE
fix: ensure partner db validity with concurrency>1

### DIFF
--- a/yearn/partners/snapshot.py
+++ b/yearn/partners/snapshot.py
@@ -80,6 +80,7 @@ class Wrapper:
         self.name = name
         self.vault = convert.to_address(vault)
         self.wrapper = convert.to_address(wrapper)
+        self.semaphore = asyncio.Semaphore(1)
     
     @cached_property
     def _vault(self) -> Vault:
@@ -365,60 +366,61 @@ class Partner:
 
     async def process(self, use_postgres_cache: bool = USE_POSTGRES_CACHE) -> Tuple[DataFrame,DataFrame]:
         # TODO Optimize this a bit better.
-
         # snapshot wrapper share at each harvest
         wrappers = []
         for wrapper in tqdm(self.flat_wrappers, self.name):
-            # NOTE this is all sync code
-            # TODO optimize this section
-            if use_postgres_cache: 
-                cache = wrapper.read_cache()
-                try:
-                    max_cached_block = int(cache['block'].max())
-                    logger.debug(f'{self.name} {wrapper.name} is cached thru block {max_cached_block}')
-                    start_block = max_cached_block + 1 if self.start_block is None else max(self.start_block, max_cached_block + 1)
-                except KeyError:
+            # NOTE: We need to use a semaphore here to ensure only one active coroutine is filling the db
+            async with wrapper.semaphore:
+                # NOTE this is all sync code
+                # TODO optimize this section
+                if use_postgres_cache: 
+                    cache = wrapper.read_cache()
+                    try:
+                        max_cached_block = int(cache['block'].max())
+                        logger.debug(f'{self.name} {wrapper.name} is cached thru block {max_cached_block}')
+                        start_block = max_cached_block + 1 if self.start_block is None else max(self.start_block, max_cached_block + 1)
+                    except KeyError:
+                        start_block = self.start_block
+                        logger.debug(f'no harvests cached for {self.name} {wrapper.name}')
+                    logger.debug(f'start block: {start_block}')
+                else:
                     start_block = self.start_block
-                    logger.debug(f'no harvests cached for {self.name} {wrapper.name}')
-                logger.debug(f'start block: {start_block}')
-            else:
-                start_block = self.start_block
-            
-            protocol_fees = wrapper.protocol_fees(start_block=start_block)
-            # NOTE end sync code
-            
-            try:
-                blocks, protocol_fees = zip(*protocol_fees.items())
-                timestamps, balances, total_supplys, vault_prices = await asyncio.gather(
-                    get_timestamps(blocks),
-                    wrapper.balances(blocks),
-                    wrapper.total_supplies(blocks),
-                    wrapper.vault_prices(blocks),
-                )
-                wrap = DataFrame(
-                    {
-                        'block': blocks,
-                        'timestamp': timestamps,
-                        'protocol_fee': protocol_fees,
-                        'balance': balances,
-                        'total_supply': total_supplys,
-                        'vault_price': vault_prices,
-                    }
-                )
-                wrap['balance_usd'] = wrap.balance * wrap.vault_price
-                wrap['share'] = wrap.balance / wrap.total_supply
-                wrap['payout_base'] = wrap.share * wrap.protocol_fee * Decimal(1 - OPEX_COST)
-                wrap['protocol_fee'] = wrap.protocol_fee
-                wrap['wrapper'] = wrapper.wrapper
-                wrap['vault'] = wrapper.vault
-            except ValueError as e:
-                if str(e) != 'not enough values to unpack (expected 2, got 0)':
-                    raise
-                wrap = DataFrame()
+                
+                protocol_fees = wrapper.protocol_fees(start_block=start_block)
+                # NOTE end sync code
+                
+                try:
+                    blocks, protocol_fees = zip(*protocol_fees.items())
+                    timestamps, balances, total_supplys, vault_prices = await asyncio.gather(
+                        get_timestamps(blocks),
+                        wrapper.balances(blocks),
+                        wrapper.total_supplies(blocks),
+                        wrapper.vault_prices(blocks),
+                    )
+                    wrap = DataFrame(
+                        {
+                            'block': blocks,
+                            'timestamp': timestamps,
+                            'protocol_fee': protocol_fees,
+                            'balance': balances,
+                            'total_supply': total_supplys,
+                            'vault_price': vault_prices,
+                        }
+                    )
+                    wrap['balance_usd'] = wrap.balance * wrap.vault_price
+                    wrap['share'] = wrap.balance / wrap.total_supply
+                    wrap['payout_base'] = wrap.share * wrap.protocol_fee * Decimal(1 - OPEX_COST)
+                    wrap['protocol_fee'] = wrap.protocol_fee
+                    wrap['wrapper'] = wrapper.wrapper
+                    wrap['vault'] = wrapper.vault
+                except ValueError as e:
+                    if str(e) != 'not enough values to unpack (expected 2, got 0)':
+                        raise
+                    wrap = DataFrame()
 
-            if use_postgres_cache:
-                cache_data(wrap)
-                wrap = pd.concat([wrap,cache])
+                if use_postgres_cache:
+                    cache_data(wrap)
+                    wrap = pd.concat([wrap,cache])
             
             try:
                 wrap = wrap.set_index('block')


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
I added a semaphore to ensure that with COONCURRENCY>1, the partners db still maintains its integrity

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
