### PR TITLE
fix: don't price alETH with uni_v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.3
 python-telegram-bot==13.15
-ypricemagic==2.8.3
+git+https://www.github.com/BobTheBuidler/ypricemagic@db8425581a315267024695c9b4819f3547f83448
 git+https://www.github.com/BobTheBuidler/eth-portfolio@22bd89a64b8d9d0ae66e390cc16ebb5ff694ed8d
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray


### PR DESCRIPTION
Related issue # (if applicable):
https://github.com/BobTheBuidler/ypricemagic/pull/318

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
