### PR TITLE
fix: velo vaults with 0 strats should not break apy calcs (0x9778589c…

### DIFF
--- a/yearn/apy/velo.py
+++ b/yearn/apy/velo.py
@@ -9,7 +9,7 @@ from brownie import ZERO_ADDRESS, chain
 from y import Contract, Network, magic
 from y.time import get_block_timestamp_async
 
-from yearn.apy.common import SECONDS_PER_YEAR, Apy, ApyFees, ApySamples
+from yearn.apy.common import SECONDS_PER_YEAR, Apy, ApyFees, ApyPoints, ApySamples
 from yearn.debug import Debug
 
 if TYPE_CHECKING:
@@ -28,6 +28,9 @@ async def get_staking_pool(underlying: str) -> Optional[Contract]:
         return None if staking_pool == ZERO_ADDRESS else await Contract.coroutine(staking_pool)
         
 async def staking(vault: "Vault", staking_rewards: Contract, samples: ApySamples, block: Optional[int]=None) -> float:
+    if len(vault.strategies) == 0:
+        return Apy("v2:velo_no_strats", 0, 0, ApyFees(0, 0), ApyPoints(0, 0, 0))
+
     end = await staking_rewards.periodFinish.coroutine(block_identifier=block)
     current_time = time() if block is None else await get_block_timestamp_async(block)
     total_supply = await staking_rewards.totalSupply.coroutine(block_identifier=block) if hasattr(staking_rewards, "totalSupply") else 0


### PR DESCRIPTION
…8e0417687cF5D3Dd2eD7C4ec01d7e53B, 0x93d6D0AB2b2aA25580cb77e8C5f9D5a0cc5E08Fe).

Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
