### PR TITLE
feat: add keep_velo to fees for ui usage

### DIFF
--- a/yearn/apy/common.py
+++ b/yearn/apy/common.py
@@ -23,6 +23,7 @@ class ApyFees:
     management: Optional[float] = None
     keep_crv: Optional[float] = None
     cvx_keep_crv: Optional[float] = None
+    keep_velo: Optional[float] = None
 
 @dataclass
 class ApyBlocks:

--- a/yearn/apy/velo.py
+++ b/yearn/apy/velo.py
@@ -37,9 +37,9 @@ async def staking(vault: "Vault", staking_rewards: Contract, samples: ApySamples
     rate = await staking_rewards.rewardRate.coroutine(block_identifier=block) if hasattr(staking_rewards, "rewardRate") else 0
     performance = await vault.vault.performanceFee.coroutine(block_identifier=block) / 1e4 if hasattr(vault.vault, "performanceFee") else 0
     management = await vault.vault.managementFee.coroutine(block_identifier=block) / 1e4 if hasattr(vault.vault, "managementFee") else 0
-    keep = await vault.strategies[0].strategy.localKeepVELO.coroutine(block_identifier=block) if hasattr(vault.strategies[0].strategy, "localKeepVELO") else 0
-    rate = rate * (10000 - keep) / 10000
-    fees = ApyFees(performance=performance, management=management)
+    keep = await vault.strategies[0].strategy.localKeepVELO.coroutine(block_identifier=block) / 1e4 if hasattr(vault.strategies[0].strategy, "localKeepVELO") else 0
+    rate = rate * (1 - keep)
+    fees = ApyFees(performance=performance, management=management, keep_velo=keep)
     
     if end < current_time or total_supply == 0 or rate == 0:
         return Apy("v2:velo_unpopular", gross_apr=0, net_apy=0, fees=fees)


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:

adding keepVELO info to exporter so it can be more easily accessed by the FE for displaying fees, similar to keepCRV

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
