### PR TITLE
feat: add base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ down:
 .PHONY: build
 build:
 	docker build -t ghcr.io/yearn/yearn-exporter .
-
 logs:
 	$(eval filter = $(if $(filter),yearn-exporter-$(filter),$(if $(network),$(network),yearn-exporter-worker)))
 	$(eval since = $(if $(since),$(since),300s))

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 #######################################
 # specify all supported networks here #
 #######################################
-supported_networks := ethereum fantom arbitrum optimism
+supported_networks := ethereum fantom arbitrum optimism base
 
 ###############################################
 # specify all supported exporter scripts here #
@@ -98,6 +98,7 @@ up:
 	make down filter=yearn-exporter-worker-fantom-exporters-treasury-transactions
 	make down filter=yearn-exporter-worker-arbitrum-exporters-treasury-transactions
 	make down filter=yearn-exporter-worker-optimism-exporters-treasury-transactions
+	make down filter=yearn-exporter-worker-base-exporters-treasury-transactions
 
 # LOGGING
 	$(eval with_logs = $(if $(with_logs),$(with_logs),true))
@@ -196,6 +197,10 @@ optimism:
 # Gnosis Chain
 gnosis:
 	make up logs network=gnosis
+
+# Base Chain
+base:
+	make up logs network=base
 
 ############################
 # Exporter-specifc recipes #

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ down:
 
 .PHONY: build
 build:
-	docker build -t ghcr.io/yearn/yearn-exporter . --no-cache
+	docker build -t ghcr.io/yearn/yearn-exporter .
 logs:
 	$(eval filter = $(if $(filter),yearn-exporter-$(filter),$(if $(network),$(network),yearn-exporter-worker)))
 	$(eval since = $(if $(since),$(since),300s))

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ down:
 
 .PHONY: build
 build:
-	docker build -t ghcr.io/yearn/yearn-exporter .
+	docker build -t ghcr.io/yearn/yearn-exporter . --no-cache
 logs:
 	$(eval filter = $(if $(filter),yearn-exporter-$(filter),$(if $(network),$(network),yearn-exporter-worker)))
 	$(eval since = $(if $(since),$(since),300s))

--- a/brownie_init.sh
+++ b/brownie_init.sh
@@ -3,8 +3,9 @@ set -e
 
 BROWNIE_NETWORK=${BROWNIE_NETWORK:-mainnet} # default to Ethereum mainnet
 EXPLORER=${EXPLORER:-$DEFAULT_EXPLORER}
+brownie networks add Base base-main host=https://base.meowrpc.com chainid=8453 explorer=https://api.basescan.org/api || true
 
-# modify the network
+# modify the network & add Base network
 if [[ ! -z "$WEB3_PROVIDER" ]]; then
   brownie networks modify $BROWNIE_NETWORK host=$WEB3_PROVIDER explorer=$EXPLORER
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
-git+https://www.github.com/BobTheBuidler/ypricemagic@f501f578d50f7f8d654d9922524c4a0219d98723
+git+https://www.github.com/BobTheBuidler/ypricemagic@3c298bd769342eeecb7ef10fa5872350077c1241
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
 git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
-git+https://www.github.com/BobTheBuidler/ypricemagic@b4003452e402288860b40e76ab65a8fa492d1916
+git+https://www.github.com/BobTheBuidler/ypricemagic@0b56582324b0b3f8c4f239b250950165fb1372c3
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
 git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
-git+https://www.github.com/BobTheBuidler/ypricemagic@0b56582324b0b3f8c4f239b250950165fb1372c3
+git+https://www.github.com/BobTheBuidler/ypricemagic@6e796f346fa1c5348a37c401f1cf6eaf50336fd6
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,13 +18,13 @@ pony>=0.7.16
 sqlalchemy>=1.4.41
 sentry-sdk==1.27.1
 pytest-bdd>=5.0.0
-dank_mids>=4.20.59
+dank_mids==4.20.60
 eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
-git+https://www.github.com/BobTheBuidler/ypricemagic@6e796f346fa1c5348a37c401f1cf6eaf50336fd6
-git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
+git+https://www.github.com/BobTheBuidler/ypricemagic@363075f21015a4bf38e70419350ce670497a53d8
+git+https://www.github.com/BobTheBuidler/eth-portfolio@6c71e6200663063c92b7d7f27bbafba7a0b02997
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray
 git+https://www.github.com/BobTheBuidler/async-lru@1364553fbe0b2f0120a2659dca292189dc1e37ef

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
 git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
-git+https://www.github.com/BobTheBuidler/ypricemagic@7b25bf20040e95f9bdca62b7721345e99e92d1f2
+git+https://www.github.com/BobTheBuidler/ypricemagic@b4003452e402288860b40e76ab65a8fa492d1916
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,9 @@ eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
-git+https://www.github.com/BobTheBuidler/ypricemagic@3c298bd769342eeecb7ef10fa5872350077c1241
+git+https://www.github.com/BobTheBuidler/dank_mids@0846d5d14ac57cf08e1525f8e88fdc8d82f322c9
+git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
+git+https://www.github.com/BobTheBuidler/ypricemagic@7b25bf20040e95f9bdca62b7721345e99e92d1f2
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
 git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
-git+https://www.github.com/BobTheBuidler/ypricemagic@6e796f346fa1c5348a37c401f1cf6eaf50336fd6
-git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
+git+https://www.github.com/BobTheBuidler/ypricemagic@363075f21015a4bf38e70419350ce670497a53d8
+git+https://www.github.com/BobTheBuidler/eth-portfolio@6c71e6200663063c92b7d7f27bbafba7a0b02997
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray
 git+https://www.github.com/BobTheBuidler/async-lru@1364553fbe0b2f0120a2659dca292189dc1e37ef

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
-git+https://www.github.com/BobTheBuidler/dank_mids@0846d5d14ac57cf08e1525f8e88fdc8d82f322c9
 git+https://www.github.com/banteg/multicall.py@5cdb0f08ddadf1c381dc0966b8bd71e3ac7c6272
 git+https://www.github.com/BobTheBuidler/ypricemagic@7b25bf20040e95f9bdca62b7721345e99e92d1f2
 git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,8 @@ eth_retry>=0.1.18
 eth-hash[pysha3]
 ez-a-sync==0.6.6
 python-telegram-bot==13.15
-git+https://www.github.com/BobTheBuidler/ypricemagic@363075f21015a4bf38e70419350ce670497a53d8
-git+https://www.github.com/BobTheBuidler/eth-portfolio@6c71e6200663063c92b7d7f27bbafba7a0b02997
+git+https://www.github.com/BobTheBuidler/ypricemagic@f501f578d50f7f8d654d9922524c4a0219d98723
+git+https://www.github.com/BobTheBuidler/eth-portfolio@5b9c344ffdb29a0354088f311c1f5c39b1e12657
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray
 git+https://www.github.com/BobTheBuidler/async-lru@1364553fbe0b2f0120a2659dca292189dc1e37ef

--- a/scripts/exporters/transactions.py
+++ b/scripts/exporters/transactions.py
@@ -39,7 +39,7 @@ BATCH_SIZE = {
     Network.Gnosis: 2_000_000,
     Network.Arbitrum: 1_500_000,
     Network.Optimism: 4_000_000,
-    Network.Base: 1_000_000,
+    Network.Base: 10_000,
 }[chain.id]
 
 FIRST_END_BLOCK = {
@@ -48,7 +48,7 @@ FIRST_END_BLOCK = {
     Network.Gnosis: 21_440_000, # # NOTE block some arbitrary time after first vault deployment
     Network.Arbitrum: 4_837_859,
     Network.Optimism: 18_111_485,
-    Network.Base: 3_263_458,
+    Network.Base: 3_571_971,
 }[chain.id]
 
 def main():

--- a/scripts/exporters/transactions.py
+++ b/scripts/exporters/transactions.py
@@ -39,6 +39,7 @@ BATCH_SIZE = {
     Network.Gnosis: 2_000_000,
     Network.Arbitrum: 1_500_000,
     Network.Optimism: 4_000_000,
+    Network.Base: 1_000_000,
 }[chain.id]
 
 FIRST_END_BLOCK = {
@@ -47,6 +48,7 @@ FIRST_END_BLOCK = {
     Network.Gnosis: 21_440_000, # # NOTE block some arbitrary time after first vault deployment
     Network.Arbitrum: 4_837_859,
     Network.Optimism: 18_111_485,
+    Network.Base: 3_263_458,
 }[chain.id]
 
 def main():

--- a/scripts/exporters/transactions.py
+++ b/scripts/exporters/transactions.py
@@ -39,7 +39,7 @@ BATCH_SIZE = {
     Network.Gnosis: 2_000_000,
     Network.Arbitrum: 1_500_000,
     Network.Optimism: 4_000_000,
-    Network.Base: 10_000,
+    Network.Base: 100_000,
 }[chain.id]
 
 FIRST_END_BLOCK = {

--- a/scripts/exporters/vaults.py
+++ b/scripts/exporters/vaults.py
@@ -41,6 +41,7 @@ elif Network(chain.id) == Network.Mainnet:
 elif Network(chain.id) == Network.Base:
     # end: release registry Aug-29-2023 01:37:43 PM +UTC block 3263458
     start = datetime(2023, 8, 29, tzinfo=timezone.utc)
+    data_query = 'yearn_vault{network="' + Network.label() + '"}'
 else:
     raise NotImplementedError()
 

--- a/scripts/exporters/vaults.py
+++ b/scripts/exporters/vaults.py
@@ -38,6 +38,9 @@ elif Network(chain.id) == Network.Mainnet:
     # end: 2020-02-12 first iearn deployment
     start = datetime(2020, 2, 12, 0, 1, tzinfo=timezone.utc)
     data_query = 'iearn{network="' + Network.label() + '"}'
+elif Network(chain.id) == Network.Base:
+    # end: release registry Aug-29-2023 01:37:43 PM +UTC block 3263458
+    start = datetime(2023, 8, 29, tzinfo=timezone.utc)
 else:
     raise NotImplementedError()
 

--- a/scripts/exporters/wallets.py
+++ b/scripts/exporters/wallets.py
@@ -24,7 +24,12 @@ yearn = Yearn(load_strategies=False, watch_events_forever=False)
 
 # start: 2020-02-12 first iearn deployment
 # start opti: 2022-01-01 an arbitrary start timestamp because the default start is < block 1 on opti and messes things up
-start = datetime(2022, 1, 1, tzinfo=timezone.utc) if chain.id in [Network.Arbitrum, Network.Optimism] else datetime(2020, 2, 12, tzinfo=timezone.utc)
+if chain.id in [Network.Arbitrum, Network.Optimism]:
+    start = datetime(2022, 1, 1, tzinfo=timezone.utc),
+elif chain.id in Network.Base:
+    start = datetime(2023, 9, 1, tzinfo=timezone.utc),
+else:
+    start = datetime(2020, 2, 12, tzinfo=timezone.utc)
 
 @ttl_cache(ttl=60)
 def get_last_recorded_block():

--- a/scripts/exporters/wallets.py
+++ b/scripts/exporters/wallets.py
@@ -26,7 +26,7 @@ yearn = Yearn(load_strategies=False, watch_events_forever=False)
 # start opti: 2022-01-01 an arbitrary start timestamp because the default start is < block 1 on opti and messes things up
 if chain.id in [Network.Arbitrum, Network.Optimism]:
     start = datetime(2022, 1, 1, tzinfo=timezone.utc),
-elif chain.id in Network.Base:
+elif Network.Base:
     start = datetime(2023, 9, 1, tzinfo=timezone.utc),
 else:
     start = datetime(2020, 2, 12, tzinfo=timezone.utc)

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -162,7 +162,7 @@ async def get_registry_adapter():
     elif chain.id == Network.Optimism:
         registry_adapter_address = "0xBcfCA75fF12E2C1bB404c2C216DBF901BE047690"
     elif chain.id == Network.Base:
-        registry_adapter_address = "0xACd0CEa837A6E6f5824F4Cac6467a67dfF4B0868"
+        registry_adapter_address = "0xF3885eDe00171997BFadAa98E01E167B53a78Ec5"
     return await Contract.coroutine(registry_adapter_address)
 
 

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -162,7 +162,7 @@ async def get_registry_adapter():
     elif chain.id == Network.Optimism:
         registry_adapter_address = "0xBcfCA75fF12E2C1bB404c2C216DBF901BE047690"
     elif chain.id == Network.Base:
-        registry_adapter_address = "0xF3885eDe00171997BFadAa98E01E167B53a78Ec5"
+        registry_adapter_address = "0xACd0CEa837A6E6f5824F4Cac6467a67dfF4B0868"
     return await Contract.coroutine(registry_adapter_address)
 
 

--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -161,6 +161,8 @@ async def get_registry_adapter():
         registry_adapter_address = "0x57AA88A0810dfe3f9b71a9b179Dd8bF5F956C46A"
     elif chain.id == Network.Optimism:
         registry_adapter_address = "0xBcfCA75fF12E2C1bB404c2C216DBF901BE047690"
+    elif chain.id == Network.Base:
+        registry_adapter_address = "0xACd0CEa837A6E6f5824F4Cac6467a67dfF4B0868"
     return await Contract.coroutine(registry_adapter_address)
 
 

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -92,6 +92,7 @@ x-envs: &envs
   - FTMSCAN_TOKEN
   - ARBISCAN_TOKEN
   - OPTISCAN_TOKEN
+  - BASESCAN_TOKEN
 
   # POSTGRES ENVS
   - PGHOST=postgres

--- a/set_network_envs.sh
+++ b/set_network_envs.sh
@@ -44,6 +44,13 @@ elif [[ "$network" =~ ^op$|^OPTI$|^opti$|^optimism$ ]]; then
   export EXPLORER=$OPTI_EXPLORER
   export DEFAULT_EXPLORER=https://api-optimistic.etherscan.io/api
 
+elif [[ "$network" =~ ^base$|^BASE$]]; then
+  export NETWORK=base
+  export BROWNIE_NETWORK=base-main
+  export WEB3_PROVIDER=$BASE_WEB3_PROVIDER
+  export EXPLORER=$BASE_EXPLORER
+  export DEFAULT_EXPLORER=https://api.basescan.org/api
+
 else
   echo "Error! Unsupported network $network specified!"
   exit 1

--- a/set_network_envs.sh
+++ b/set_network_envs.sh
@@ -44,7 +44,7 @@ elif [[ "$network" =~ ^op$|^OPTI$|^opti$|^optimism$ ]]; then
   export EXPLORER=$OPTI_EXPLORER
   export DEFAULT_EXPLORER=https://api-optimistic.etherscan.io/api
 
-elif [[ "$network" =~ ^base$|^BASE$]]; then
+elif [[ "$network" =~ ^base$|^BASE$ ]]; then
   export NETWORK=base
   export BROWNIE_NETWORK=base-main
   export WEB3_PROVIDER=$BASE_WEB3_PROVIDER

--- a/yearn/constants.py
+++ b/yearn/constants.py
@@ -45,6 +45,9 @@ STRATEGIST_MULTISIG = {
     Network.Optimism: {
         "0xea3a15df68fCdBE44Fdb0DB675B2b3A14a148b26",
     },
+    Network.Base: {
+        "0x01fE3347316b2223961B20689C65eaeA71348e93",
+    },
 }.get(chain.id,set())
 
 STRATEGIST_MULTISIG = {convert.to_address(address) for address in STRATEGIST_MULTISIG}
@@ -55,6 +58,7 @@ YCHAD_MULTISIG = {
     Network.Gnosis:     "0x22eAe41c7Da367b9a15e942EB6227DF849Bb498C",
     Network.Arbitrum:   "0xb6bc033d34733329971b938fef32fad7e98e56ad",
     Network.Optimism:   "0xF5d9D6133b698cE29567a90Ab35CfB874204B3A7",
+    Network.Base:       "0xbfAABa9F56A39B814281D68d2Ad949e88D06b02E",
 }.get(chain.id, None)
 
 if YCHAD_MULTISIG:
@@ -65,6 +69,7 @@ TREASURY_MULTISIG = {
     Network.Fantom:     "0x89716Ad7EDC3be3B35695789C475F3e7A3Deb12a",
     Network.Arbitrum:   "0x1deb47dcc9a35ad454bf7f0fcdb03c09792c08c1",
     Network.Optimism:   "0x84654e35E504452769757AAe5a8C7C6599cBf954",
+    Network.Base:       "0x02ff746D8cb62709aEEc611CeC9B17d7dD1D3480",
 }.get(chain.id, None)
 
 if TREASURY_MULTISIG:
@@ -96,6 +101,10 @@ TREASURY_WALLETS = {
         YCHAD_MULTISIG,
         TREASURY_MULTISIG,
     },
+    Network.Base: {
+        YCHAD_MULTISIG,
+        TREASURY_MULTISIG, 
+    }
 }.get(chain.id,set())
 
 TREASURY_WALLETS = {convert.to_address(address) for address in TREASURY_WALLETS}

--- a/yearn/middleware/middleware.py
+++ b/yearn/middleware/middleware.py
@@ -27,6 +27,7 @@ CHAIN_MAX_BATCH_SIZE = {
     Network.Fantom: 10_000,  # 0.1 days
     Network.Arbitrum: 20_000, # 0.34 days
     Network.Optimism: 800_000, # 10.02 days
+    Network.Base: 800_000, # test value
 }
 
 def _get_batch_size() -> int:

--- a/yearn/multicall2.py
+++ b/yearn/multicall2.py
@@ -24,7 +24,8 @@ MULTICALL2 = {
     Network.Gnosis: '0xFAa296891cA6CECAF2D86eF5F7590316d0A17dA0', # maker has not yet deployed multicall2. This is from another deployment
     Network.Fantom: '0xD98e3dBE5950Ca8Ce5a4b59630a5652110403E5c',
     Network.Arbitrum: '0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858',
-    Network.Optimism: '0xcA11bde05977b3631167028862bE2a173976CA11' # Multicall 3
+    Network.Optimism: '0xcA11bde05977b3631167028862bE2a173976CA11', # Multicall 3
+    Network.Base: '0xcA11bde05977b3631167028862bE2a173976CA11' # MC3
 }
 multicall2 = contract(MULTICALL2[chain.id])
 

--- a/yearn/partners/delegated.py
+++ b/yearn/partners/delegated.py
@@ -15,6 +15,7 @@ YEARN_PARTNER_TRACKER = Contract({
     Network.Fantom: "0x086865B2983320b36C42E48086DaDc786c9Ac73B",
     Network.Arbitrum: "0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7",
     Network.Optimism: "0x7E08735690028cdF3D81e7165493F1C34065AbA2",
+    Network.Base: "0xD0F08E42A40569fF83D28AA783a5b6537462667c",
 }[chain.id])
 
 class AsOfDict(dict):

--- a/yearn/prices/constants.py
+++ b/yearn/prices/constants.py
@@ -26,6 +26,10 @@ tokens_by_network = {
         'weth': '0x4200000000000000000000000000000000000006',
         'usdc': '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
         'dai': '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
+    },
+    Network.Base: {
+        'weth': '0x4200000000000000000000000000000000000006',
+        'dai': '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
     }
 }
 
@@ -87,15 +91,21 @@ stablecoins_by_network = {
         '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': 'dai',
         '0x2E3D870790dC77A83DD1d18184Acc7439A53f475': 'frax',
         '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9': 'susd',
+    },
+    Network.Base: {
+        '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA': 'usdbc',
+        '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb': 'dai',
+        '0x4A3A6Dd60A34bB2Aba60D73B4C88315E9CeB6A3D': 'mim',
     }
 }
 
 ib_snapshot_block_by_network = {
     Network.Mainnet: 14051986,
     Network.Fantom: 28680044,
-    Network.Gnosis: 1, # TODO revisit as IB is not deployed in gnosis
-    Network.Arbitrum: 1,
+    Network.Gnosis: 1, # TODO revisit as IB is not deployed on gnosis
+    Network.Arbitrum: 1, # TODO revisit as IB is not deployed on arbitrum
     Network.Optimism: 12658427,
+    Network.Base: 1, # TODO revisit as IB is not deployed on base
 }
 
 # We convert to checksum address here to prevent minor annoyances. It's worth it.

--- a/yearn/prices/constants.py
+++ b/yearn/prices/constants.py
@@ -30,6 +30,9 @@ tokens_by_network = {
     Network.Base: {
         'weth': '0x4200000000000000000000000000000000000006',
         'dai': '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
+        'usdc': '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA', #temp
+        'usdt': '0x4A3A6Dd60A34bB2Aba60D73B4C88315E9CeB6A3D', #temp
+        'wbtc': '0x77852193BD608A518dd7b7C2f891A1d02ceeB4d4', #temp
     }
 }
 

--- a/yearn/prices/curve.py
+++ b/yearn/prices/curve.py
@@ -130,6 +130,9 @@ class CurveRegistry(metaclass=Singleton):
 
     @sentry_catch_all
     def watch_events(self) -> None:
+        if chain.id == Network.Base:
+            # No curve pool
+            return
         sleep_time = 600
         registries = []
         registry_logs = []

--- a/yearn/prices/uniswap/v2.py
+++ b/yearn/prices/uniswap/v2.py
@@ -75,6 +75,13 @@ addresses: List[Dict[str,str]] = {
             'router': '0xE6Df0BB08e5A97b40B21950a0A51b94c4DbA0Ff6',
 
         }
+    ],
+    Network.Base: [
+        {
+            'name': 'sushiswap',
+            'factory': '0x71524B4f93c58fcbF659783284E38825f0622859',
+            'router': '0x6BDED42c6DA8FBf0d2bA55B2fa120C5e0c8D7891',
+        }
     ]
 }
 

--- a/yearn/prices/uniswap/v3.py
+++ b/yearn/prices/uniswap/v3.py
@@ -49,7 +49,6 @@ addresses = {
     Network.Base: {
         'factory': '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
         'fee_tiers': [3000, 500, 10_000, 100],
-
     }
 }
 

--- a/yearn/prices/uniswap/v3.py
+++ b/yearn/prices/uniswap/v3.py
@@ -65,7 +65,7 @@ class UniswapV3(metaclass=Singleton):
         self.factory: Contract = contract(conf['factory'])
         self.quoter: Contract = Contract.from_abi(
             name='Quoter',
-            address=addresses[chainid]['quoter'],
+            address=addresses[chain.id]['quoter'],
             abi=json.load(open('interfaces/uniswap/UniswapV3Quoter.json'))
         ) # use direct abi from etherscan because the quoter is not verified on all chains (opti)
         self.fee_tiers = [FeeTier(fee) for fee in conf['fee_tiers']]

--- a/yearn/prices/uniswap/v3.py
+++ b/yearn/prices/uniswap/v3.py
@@ -46,6 +46,11 @@ addresses = {
         'factory': UNISWAP_V3_FACTORY,
         'fee_tiers': [3000, 500, 10_000, 100],
     },
+    Network.Base: {
+        'factory': '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
+        'fee_tiers': [3000, 500, 10_000, 100],
+
+    }
 }
 
 

--- a/yearn/prices/uniswap/v3.py
+++ b/yearn/prices/uniswap/v3.py
@@ -29,29 +29,32 @@ Path = List[Union[Address,FeeTier]]
 
 # https://github.com/Uniswap/uniswap-v3-periphery/blob/main/deploys.md
 UNISWAP_V3_FACTORY = '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+UNISWAP_V3_QUOTER = '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6'
 FEE_DENOMINATOR = 1_000_000
 USDC_SCALE = 1e6
 
-# same addresses on all networks
 addresses = {
     Network.Mainnet: {
         'factory': UNISWAP_V3_FACTORY,
+        'quoter': UNISWAP_V3_QUOTER,
         'fee_tiers': [3000, 500, 10_000, 100],
     },
     Network.Arbitrum: {
         'factory': UNISWAP_V3_FACTORY,
+        'quoter': UNISWAP_V3_QUOTER,
         'fee_tiers': [3000, 500, 10_000],
     },
     Network.Optimism: {
         'factory': UNISWAP_V3_FACTORY,
+        'quoter': UNISWAP_V3_QUOTER,
         'fee_tiers': [3000, 500, 10_000, 100],
     },
     Network.Base: {
         'factory': '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
+        'quoter': '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a', # quoter v2
         'fee_tiers': [3000, 500, 10_000, 100],
     }
 }
-
 
 class UniswapV3(metaclass=Singleton):
     def __init__(self) -> None:
@@ -62,7 +65,7 @@ class UniswapV3(metaclass=Singleton):
         self.factory: Contract = contract(conf['factory'])
         self.quoter: Contract = Contract.from_abi(
             name='Quoter',
-            address='0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
+            address=addresses[chainid]['quoter'],
             abi=json.load(open('interfaces/uniswap/UniswapV3Quoter.json'))
         ) # use direct abi from etherscan because the quoter is not verified on all chains (opti)
         self.fee_tiers = [FeeTier(fee) for fee in conf['fee_tiers']]

--- a/yearn/prices/yearn.py
+++ b/yearn/prices/yearn.py
@@ -31,6 +31,9 @@ addresses = {
     Network.Optimism: {
         'v2': '0xBcfCA75fF12E2C1bB404c2C216DBF901BE047690',
     },
+    Network.Base: {
+        'v2': '0xACd0CEa837A6E6f5824F4Cac6467a67dfF4B0868',
+    }
 }
 
 

--- a/yearn/treasury/treasury.py
+++ b/yearn/treasury/treasury.py
@@ -84,6 +84,7 @@ class YearnTreasury(ExportablePortfolio):
             Network.Gnosis: 20_000_000,
             Network.Arbitrum: 4_837_859,
             Network.Optimism: 18_100_336,
+            Network.Base: 3_264_243,
         }[chain.id]
         
         ''' TODO: confirm these starts match start_block
@@ -122,6 +123,7 @@ class StrategistMultisig(ExportablePortfolio):
             Network.Gnosis: 20_455_212,
             Network.Arbitrum: 2_434_174,
             Network.Optimism: 18_084_577,
+            Network.Base: 3_263_643,
         }[chain.id]
         super().__init__(constants.STRATEGIST_MULTISIG, label='sms', start_block=start_block, asynchronous=asynchronous, load_prices=load_prices)
 

--- a/yearn/utils.py
+++ b/yearn/utils.py
@@ -30,6 +30,7 @@ BINARY_SEARCH_BARRIER = {
     Network.Fantom: 4_564_024,  # fantom returns "missing trie node" before that
     Network.Arbitrum: 0,
     Network.Optimism: 0,
+    Network.Base: 0,
 }
 
 _erc20 = lru_cache(maxsize=None)(interface.ERC20)

--- a/yearn/v1/vaults.py
+++ b/yearn/v1/vaults.py
@@ -159,5 +159,6 @@ class VaultV1:
         except yPriceMagicError as e:
             if not isinstance(e.exception, PriceError):
                 raise e
+            price = None
         tvl = total_assets * price / 10 ** await self.vault.decimals.coroutine(block_identifier=block) if price else None
         return Tvl(total_assets, price, tvl) 

--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -66,6 +66,8 @@ class Registry(metaclass=Singleton):
                 contract('0x81291ceb9bB265185A9D07b91B5b50Df94f005BF'),
                 contract('0x8ED9F6343f057870F1DeF47AaE7CD88dfAA049A8'), # StakingRewardsRegistry
             ]
+        elif chain.id == Network.Base:
+            return [contract('0x697BC6bd64677bE63240262869dD5F2A3eEACCd3')]
         else:
             raise UnsupportedNetwork('yearn v2 is not available on this network')
 

--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -67,7 +67,7 @@ class Registry(metaclass=Singleton):
                 contract('0x8ED9F6343f057870F1DeF47AaE7CD88dfAA049A8'), # StakingRewardsRegistry
             ]
         elif chain.id == Network.Base:
-            return [contract('0x697BC6bd64677bE63240262869dD5F2A3eEACCd3')]
+            return [contract('0xF3885eDe00171997BFadAa98E01E167B53a78Ec5')]
         else:
             raise UnsupportedNetwork('yearn v2 is not available on this network')
 

--- a/yearn/v2/vaults.py
+++ b/yearn/v2/vaults.py
@@ -297,10 +297,7 @@ class Vault:
                 raise e
             price = 0
             
-        # NOTE: which one of these do we use? idk, must check
-        tvl = total_assets * price / 10 ** self.vault.decimals(block_identifier=block)
         tvl = total_assets * price / await ERC20(self.vault, asynchronous=True).scale if price else None
-        
         return Tvl(total_assets, price, tvl)
 
     @cached_property

--- a/yearn/yearn.py
+++ b/yearn/yearn.py
@@ -57,6 +57,11 @@ class Yearn:
                 "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
                 "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
             }
+        elif chain.id == Network.Base:
+            self.registries = {
+                "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
+                "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
+            }
         else:
             raise UnsupportedNetwork('yearn is not supported on this network')
 

--- a/yearn/yearn.py
+++ b/yearn/yearn.py
@@ -38,26 +38,11 @@ class Yearn:
                 "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
                 "special": yearn.special.Registry(),
             }
-        elif chain.id ==  Network.Gnosis:
+        elif chain.id in [Network.Gnosis, Network.Base]:
             self.registries = {
                 "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
             }
-        elif chain.id ==  Network.Fantom:
-            self.registries = {
-                "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
-                "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
-            }
-        elif chain.id == Network.Arbitrum:
-            self.registries = {
-                "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
-                "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
-            }
-        elif chain.id == Network.Optimism:
-            self.registries = {
-                "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
-                "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),
-            }
-        elif chain.id == Network.Base:
+        elif chain.id in [Network.Fantom, Network.Arbitrum, Network.Optimism]:
             self.registries = {
                 "v2": yearn.v2.registry.Registry(watch_events_forever=watch_events_forever),
                 "ib": yearn.ironbank.Registry(exclude_ib_tvl=exclude_ib_tvl),


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
add base network to exporter

### How I did it:

### How to verify it:
`source .env`
`make up network=base`

### Checklist:
**Network**:  Base
**Chain ID**: 8453

>Make sure all points are addressed. This is a list for adding full network support to the exporter.
To configure the network correctly you must add the following constants:

- in ./yearn/constants.py:
  - [x] specify Treasury address. (if Yearn has a treasury contract deployed) This would be the rewards() address of any vault.
  - [x] specify Multisig address. This would be the governance() address of any vault
  - [x] specify Strategist Multisig address. (if Yearn has a SMS deployed) This would be the management() address of any vault.

- in ./yearn/prices/constants.py:
  - [x] add weth address to `tokens_by_network`.
  - [x] add usdc address to `tokens_by_network`.
  - [x] add dai address to `tokens_by_network`.
  - [x] configure `stablecoins` using popular + "safe" stablecoins on the chain.
  - [x] add the {{network}} gas token address to `wrapped_gas_coin` field.

- in ./yearn/multicall2.py:
  - [x] specify the appropriate multicall2 contract address.

- in ./yearn/ironbank.py:
  - [-] add ironbank deployment address

- in ./yearn/prices/compound.py:
  - [-] add ib comptroller

- in ./yearn/v2/registry.py:
  - [x] add v2 vault release registry

- in yearn/yearn.py:
  - [x] add v2 vault registry and 
  - [-]ironbank registry

- in ./yearn/prices/constants.py:
  - [x] specify `ib_snapshot_block_by_network`, if any, the start block of Ironbank on this network or specify '1' if not applicable.

- in ./yearn/prices/uniswap/v2.py:
  - [-] specify the factory and router address for any important uni v2 forks on the chain.

in ./yearn/prices/uniswap/v3.py:
  - [x] add info about uni v3 deployed on network

- in ./yearn/utils.py:
  - [x] specify `BINARY_SEARCH_BARRIER` as 0 if all historical data is available. If historical data not available due to a network upgrade/etc, specify the first block of the available historical data.

- in ./yearn/middleware/middleware.py:
  - [-] specify `BATCH_SIZE` of approx 1 day based on avg block times on the chain.

- in ./scripts/historical-exporter.py:
  - [x] configure `end` to equal the date + hour of deployment for the first Yearn product on the chain.
  - [-] configure `data_query`. See `mapping` in ./yearn/outputs/victoria/output_helper.py to figure out the metric to specify based on what type of product was the first deployed on the chain.

- in ./scripts/historical-treasury-exporter.py:
  - [ ] configure `end` to equal the date + hour of deployment for the Yearn Treasury on the chain.
  - [ ] configure `data_query` using the existing networks as an example.

- in ./scripts/historical-sms-exporter.py:
  - [ ] configure `end` to equal the date + hour of deployment for the Strategist Multisig on the chain.
  - [ ] configure `data_query` using the existing networks as an example.

You also need to set up containers for each exporter on the new chain. This is a little more complicated but you can use existing containers as an example:
  - [x] define common envs for the chain
  - [] add one new service entry for forwards exporter
  - [ ] add one new service entry for treasury exporter
  - [ ] add one new service entry for sms exporter
  - [ ] add one new service entry for wallet exporter
  - [ ] add one new service entry for transactions exporter
  - [x] adapt entrypoint.sh

in ./Makefile: Set up network specific make command.
  - [x] network
  - [x] logs-network

It's important to test to make sure everything works!

Once you've handled everything above, type `make up <network>` into your terminal replacing network with your network name at the project root. The network specific exporters will start running in docker and any exceptions will show in your terminal. If there are no exceptions, and everything appears to be running smoothly then it should be working correctly.

- [x] yes I have tested it and it is running as expected
