### PR TITLE
fix: curve apy breaks s3 when pool is None

### DIFF
--- a/yearn/apy/curve/simple.py
+++ b/yearn/apy/curve/simple.py
@@ -110,7 +110,10 @@ def get_gauge_relative_weight_for_sidechain(gauge_address):
 
 async def simple(vault, samples: ApySamples) -> Apy:
     lp_token = vault.token.address
-    pool_address = (await y_curve.get_pool(lp_token)).address
+    pool = await y_curve.get_pool(lp_token)
+    if pool is None:
+        raise ApyError("crv", "no pool")
+    pool_address = ().address
     gauge_address = curve.get_gauge(pool_address, lp_token)
     if gauge_address is None:
         raise ApyError("crv", "no gauge")


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Added a ApyError as a fallback to catch errs and allow debuggable outputs

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
