### PR TITLE
feat: further reduce treasury-txs memory use

### DIFF
--- a/yearn/treasury/accountant/accountant.py
+++ b/yearn/treasury/accountant/accountant.py
@@ -68,6 +68,8 @@ def sort_tx(treasury_tx_id: int) -> Optional[TxGroup]:
     if txgroup != tx.txgroup:
         tx.txgroup = txgroup
         commit()
+    # Hack to reduce memory consumption
+    tx.__dict__.pop('_events', None)
     return txgroup
 
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
After each tx is sorted, the events cache is popped

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
