### PR TITLE
feat: shared ypm cache

### DIFF
--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   brownie: {}
   cache: {}
   memray: {}
+  ypricemagic: {}
 
 networks:
   yearn-exporter-infra_stack:
@@ -111,6 +112,7 @@ x-volumes: &volumes
   - brownie:/root/.brownie
   - cache:/app/yearn-exporter/cache
   - memray:/app/yearn-exporter/memray
+  - ypricemagic:/root/.ypricemagic
 
 services:
   exporter:


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
ypm has a disk cache for certain objects now. This PR shares the disk cache across containers on the same network.

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
