### PR TITLE
fix: query past and present Release Registry

### DIFF
--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -83,8 +83,9 @@ class Registry(metaclass=Singleton):
             r = contract(event['newAddress'].hex())
             registries.append(r)
             if hasattr(r, 'releaseRegistry'):
-                rr = contract(r.releaseRegistry())
-                registries.append(rr)
+                logs = get_logs_asap([str(addr) for addr in self.registries], r.topics["ReleaseRegistryUpdated"])
+                # Add all past and present Release Registries
+                registries.extend({contract(event['address']) for event in decode_logs(logs)})
         logger.info('loaded %d registry versions', len(registries))
         return registries
 

--- a/yearn/v2/registry.py
+++ b/yearn/v2/registry.py
@@ -83,7 +83,7 @@ class Registry(metaclass=Singleton):
             r = contract(event['newAddress'].hex())
             registries.append(r)
             if hasattr(r, 'releaseRegistry'):
-                logs = get_logs_asap([str(addr) for addr in self.registries], r.topics["ReleaseRegistryUpdated"])
+                logs = get_logs_asap(str(r), r.topics["ReleaseRegistryUpdated"])
                 # Add all past and present Release Registries
                 registries.extend({contract(event['address']) for event in decode_logs(logs)})
         logger.info('loaded %d registry versions', len(registries))


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
If the release registry on a particular registry was ever updated, the exporters did not know to query the old one(s). This PR fixes that.

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
