### PR TITLE
fix: thread async conflict

### DIFF
--- a/yearn/v2/strategies.py
+++ b/yearn/v2/strategies.py
@@ -8,10 +8,9 @@ from brownie import chain
 from eth_utils import encode_hex, event_abi_to_log_topic
 from multicall.utils import run_in_subprocess
 from y.exceptions import NodeNotSynced
-from y.utils.events import get_logs_asap
 
 from yearn.decorators import sentry_catch_all, wait_or_exit_after
-from yearn.events import decode_logs
+from yearn.events import decode_logs, get_logs_asap
 from yearn.multicall2 import fetch_multicall_async
 from yearn.utils import contract, safe_views
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
swapped out y get_logs_asap which should only be used in main thread with yearn get_logs_asap which will work until we dethread the startup sequence

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
