### PR TITLE
fix: balance buckets on base

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ eth-hash[pysha3]
 ez-a-sync==0.7.2
 python-telegram-bot==13.15
 git+https://www.github.com/BobTheBuidler/ypricemagic@f10e8d594480242139ce17271484dd79a39cea43
-git+https://www.github.com/BobTheBuidler/eth-portfolio@63d42011be65adc6f19167d784837e7ed2f4389a
+git+https://www.github.com/BobTheBuidler/eth-portfolio@594b4eddf979739e23efa427e3dc508bf90594dc
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray
 git+https://www.github.com/BobTheBuidler/async-lru@1364553fbe0b2f0120a2659dca292189dc1e37ef


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
curve object is not a valid object on Base chain, which created an AttributeError when sorting token buckets. 
This fixes that.

### How I did it:
Added a boolean check

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
