### PR TITLE
fix: ugly KeyErrors in alru_cache logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,9 @@ pytest-bdd>=5.0.0
 dank_mids==4.20.61
 eth_retry>=0.1.18
 eth-hash[pysha3]
-ez-a-sync==0.7.2
+ez-a-sync==0.7.4
 python-telegram-bot==13.15
 git+https://www.github.com/BobTheBuidler/ypricemagic@f10e8d594480242139ce17271484dd79a39cea43
 git+https://www.github.com/BobTheBuidler/eth-portfolio@594b4eddf979739e23efa427e3dc508bf90594dc
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray
-git+https://www.github.com/BobTheBuidler/async-lru@1364553fbe0b2f0120a2659dca292189dc1e37ef


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
I pulled 2 fixes from upstream alru_cache lib into the threadsafe version on my github
Then I pushed the fixed threadsafe version to pypi and replaced the nonthreadsafe version with the theadsafe version in ez-a-sync
Last I removed the now unnecessary commit hash from requirements.txt

### How I did it:

### How to verify it:
Things run, no prob

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
