### PR TITLE
fix: wallets exporter data_query not chain-aware

### DIFF
--- a/scripts/exporters/wallets.py
+++ b/scripts/exporters/wallets.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import sentry_sdk
 from brownie import chain
 from cachetools.func import ttl_cache
-from y.networks import Network
+from y import Network
 from y.time import closest_block_after_timestamp
 
 from yearn import constants
@@ -49,7 +49,7 @@ class WalletExporter(Exporter):
 
 exporter = WalletExporter(
     name = "wallets",
-    data_query = 'aggregate{param="total wallets"}',
+    data_query = 'aggregate{param="total wallets", network="' + Network.label() + '"}',
     data_fn = yearn.wallet_data_for_export,
     export_fn = _post,
     start_block = closest_block_after_timestamp(int(start.timestamp())) - 1,


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Added network param to wallets exporter's data_query

### How I did it:
Added network param to wallets exporter's data_query

### How to verify it:
run wallets exporter on previously "full" db, watch new blocks magically appear

### Checklist:
- [x] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
