### PR TITLE
fix: read assets per block and get rate_provider from the pool itself

### DIFF
--- a/yearn/apy/common.py
+++ b/yearn/apy/common.py
@@ -57,6 +57,7 @@ class ApySamples:
     now: int
     week_ago: int
     month_ago: int
+    day_ago: int
 
 
 class ApyError(ValueError):
@@ -86,4 +87,5 @@ def get_samples(now_time: Optional[datetime] = None) -> ApySamples:
         now = closest_block_after_timestamp(int(now_time.timestamp()), True)
     week_ago = closest_block_after_timestamp(int((now_time - timedelta(days=7)).timestamp()), True)
     month_ago = closest_block_after_timestamp(int((now_time - timedelta(days=31)).timestamp()), True)
-    return ApySamples(now, week_ago, month_ago)
+    day_ago = closest_block_after_timestamp(int((now_time - timedelta(days=1)).timestamp()), True)
+    return ApySamples(now, week_ago, month_ago, day_ago)


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
