### PR TITLE
feat: proper type checking for ez-a-sync functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pytest-bdd>=5.0.0
 dank_mids==4.20.64
 eth_retry>=0.1.18
 eth-hash[pysha3]
-ez-a-sync==0.12.2
+ez-a-sync==0.12.3
 python-telegram-bot==13.15
 git+https://www.github.com/BobTheBuidler/ypricemagic@382cb3a6e35fee96f6565dbdf7b709c6d699f0d1
 git+https://www.github.com/BobTheBuidler/eth-portfolio@594b4eddf979739e23efa427e3dc508bf90594dc


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
added proper type checking to a few a_sync utils so mypy works correctly

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
