### PR TITLE
fix: decorate _get_logs_async_no_cache with eth_retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ eth_retry>=0.1.19
 eth-hash[pysha3]
 ez-a-sync==0.12.3
 python-telegram-bot==13.15
-ypricemagic==2.16.8
+ypricemagic==2.16.9
 git+https://www.github.com/BobTheBuidler/eth-portfolio@0fb0db03365404824e109893bc8e042d2f140d85
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ eth_retry>=0.1.19
 eth-hash[pysha3]
 ez-a-sync==0.12.3
 python-telegram-bot==13.15
-ypricemagic==2.16.7
+ypricemagic==2.16.8
 git+https://www.github.com/BobTheBuidler/eth-portfolio@0fb0db03365404824e109893bc8e042d2f140d85
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pony>=0.7.16
 sqlalchemy>=1.4.41
 sentry-sdk==1.27.1
 pytest-bdd>=5.0.0
-dank_mids==4.20.68
+dank_mids==4.20.69
 eth_retry>=0.1.19
 eth-hash[pysha3]
 ez-a-sync==0.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ eth_retry>=0.1.19
 eth-hash[pysha3]
 ez-a-sync==0.12.3
 python-telegram-bot==13.15
-ypricemagic==2.16.6
+ypricemagic==2.16.7
 git+https://www.github.com/BobTheBuidler/eth-portfolio@0fb0db03365404824e109893bc8e042d2f140d85
 git+https://www.github.com/BobTheBuidler/toolcache@e37b53cec64556d2b35df66767fca4c8f366a2fa
 memray


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
fixed the last case where a rate-limited response causes failure

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
