### PR TITLE
feat: 1200 less getCode calls @ startup

### DIFF
--- a/yearn/iearn.py
+++ b/yearn/iearn.py
@@ -2,13 +2,13 @@ import asyncio
 from collections import defaultdict
 
 from brownie import chain
+from y import Contract
 from y.contracts import contract_creation_block_async
 from y.networks import Network
 from y.prices import magic
 
 from yearn.exceptions import UnsupportedNetwork
 from yearn.multicall2 import fetch_multicall_async, multicall_matrix_async
-from yearn.utils import contract
 
 IEARN = {
     # v1 - deprecated
@@ -30,7 +30,7 @@ IEARN = {
 class Earn:
     def __init__(self, name, vault):
         self.name = name
-        self.vault = contract(vault)
+        self.vault = Contract(vault)
         self.token = self.vault.token()
         self.scale = 10 ** self.vault.decimals()
 


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Swap out contract for Contract, both are lru_cached but Contract for each of these contracts will be inited during ypm initialization so it makes no sense to load both for each curve pool / iearn token

YOLO merged on sunday so prod can defeat the rate limits easier

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
