### PR TITLE
fix: s3 revert on opti

### DIFF
--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -148,8 +148,7 @@ async def get_assets_metadata(vault_v2: list) -> dict:
 
 
 async def get_assets_dynamic(registry_adapter: Contract, addresses: list) -> list:
-    data = await asyncio.gather(*[registry_adapter.assetsDynamic.coroutine([address]) for address in addresses])
-    return [asset for address_data in data for asset in address_data]
+    return await asyncio.gather(*[registry_adapter.assetDynamic.coroutine(address) for address in addresses])
 
 
 async def get_registry_adapter():


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Unsure if this will fix the issue entirely but since we're using assetsDynamic but only ever passing in a 1-address array, I'm trying assetDynamic instead and hoping this will fix the reverting issue

I can't reproduce the issue with either method so... yolo

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
