### PR TITLE
fix: deprecated `version` field in docker-compose files

### DIFF
--- a/services/dashboard/docker-compose.infra.yml
+++ b/services/dashboard/docker-compose.infra.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 volumes:
   grafana_data: {}
   victoria_metrics_data: {}

--- a/services/dashboard/docker-compose.test.yml
+++ b/services/dashboard/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   brownie: {}
   cache: {}

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 volumes:
   brownie: {}
   cache: {}


### PR DESCRIPTION
Related issue # (if applicable):

### What I did:
Removed it per instructions in the warning

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
