### PR TITLE
ci: harden workflow inputs

### DIFF
--- a/.github/workflows/debug-apy-prod.yaml
+++ b/.github/workflows/debug-apy-prod.yaml
@@ -11,15 +11,40 @@ on:
         required: true
         default: ethereum
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate inputs
+        id: inputs
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
+          NETWORK: ${{ github.event.inputs.network }}
+        run: |
+          tag="${DOCKER_IMAGE_TAG:-latest}"
+          network="${NETWORK:-ethereum}"
+          if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid docker image tag: $tag" >&2
+            exit 1
+          fi
+          if [[ ! "$network" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$ ]]; then
+            echo "Invalid network: $network" >&2
+            exit 1
+          fi
+          echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "network=$network" >> "$GITHUB_OUTPUT"
       - name: Debug APY on production
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
+          NETWORK: ${{ steps.inputs.outputs.network }}
         with:
           host: ${{ secrets.APY_PRODUCTION_HOST }}
           username: ${{ secrets.APY_PRODUCTION_USERNAME }}
           key: ${{ secrets.APY_PRODUCTION_KEY }}
           port: ${{ secrets.APY_PRODUCTION_PORT }}
-          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/debug_apy.sh" -o debug_apy.sh && chmod +x debug_apy.sh && ./debug_apy.sh "${{ github.event.inputs.docker_image_tag }}" "${{ github.event.inputs.network }}"
+          envs: DOCKER_IMAGE_TAG,NETWORK
+          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/debug_apy.sh" -o debug_apy.sh && chmod +x debug_apy.sh && ./debug_apy.sh "$DOCKER_IMAGE_TAG" "$NETWORK"

--- a/.github/workflows/deploy-apy-prod.yaml
+++ b/.github/workflows/deploy-apy-prod.yaml
@@ -11,20 +11,32 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
-      - name: extract docker image tag
-        id: extract_tag
+      - name: Validate docker image tag
+        id: inputs
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
         run: |
-          TAG=${{ github.event.inputs.docker_image_tag }}
-          echo "value=${TAG:-latest}" >> $GITHUB_OUTPUT
+          tag="${DOCKER_IMAGE_TAG:-latest}"
+          if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid docker image tag: $tag" >&2
+            exit 1
+          fi
+          echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to apy production
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:
           host: ${{ secrets.APY_PRODUCTION_HOST }}
           username: ${{ secrets.APY_PRODUCTION_USERNAME }}
           key: ${{ secrets.APY_PRODUCTION_KEY }}
           port: ${{ secrets.APY_PRODUCTION_PORT }}
-          script: docker pull ghcr.io/yearn/yearn-exporter:${{ steps.extract_tag.outputs.value }}
+          envs: DOCKER_IMAGE_TAG
+          script: docker pull "ghcr.io/yearn/yearn-exporter:$DOCKER_IMAGE_TAG"

--- a/.github/workflows/deploy-revenues-prod.yaml
+++ b/.github/workflows/deploy-revenues-prod.yaml
@@ -11,20 +11,32 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
-      - name: extract docker image tag
-        id: extract_tag
+      - name: Validate docker image tag
+        id: inputs
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
         run: |
-          TAG=${{ github.event.inputs.docker_image_tag }}
-          echo "value=${TAG:-latest}" >> $GITHUB_OUTPUT
+          tag="${DOCKER_IMAGE_TAG:-latest}"
+          if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid docker image tag: $tag" >&2
+            exit 1
+          fi
+          echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to revenues production
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:
           host: ${{ secrets.REVENUES_PRODUCTION_HOST }}
           username: ${{ secrets.REVENUES_PRODUCTION_USERNAME }}
           key: ${{ secrets.REVENUES_PRODUCTION_KEY }}
           port: ${{ secrets.REVENUES_PRODUCTION_PORT }}
-          script: docker pull ghcr.io/yearn/yearn-exporter:${{ steps.extract_tag.outputs.value }}
+          envs: DOCKER_IMAGE_TAG
+          script: docker pull "ghcr.io/yearn/yearn-exporter:$DOCKER_IMAGE_TAG"

--- a/.github/workflows/deploy-ye-prod.yaml
+++ b/.github/workflows/deploy-ye-prod.yaml
@@ -11,15 +11,32 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate docker image tag
+        id: inputs
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
+        run: |
+          tag="${DOCKER_IMAGE_TAG:-latest}"
+          if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid docker image tag: $tag" >&2
+            exit 1
+          fi
+          echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to yv-production
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:
           host: ${{ secrets.YV_PRODUCTION_HOST }}
           username: ${{ secrets.YV_PRODUCTION_USERNAME }}
           key: ${{ secrets.YV_PRODUCTION_KEY }}
           port: ${{ secrets.YV_PRODUCTION_PORT }}
-          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/deploy.sh" -o deploy.sh && chmod +x deploy.sh && ./deploy.sh "${{ github.event.inputs.docker_image_tag }}" "$HOME/.env" "up" "https://yearn.vision"
+          envs: DOCKER_IMAGE_TAG
+          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/deploy.sh" -o deploy.sh && chmod +x deploy.sh && ./deploy.sh "$DOCKER_IMAGE_TAG" "$HOME/.env" "up" "https://yearn.vision"

--- a/.github/workflows/deploy-ye-staging.yaml
+++ b/.github/workflows/deploy-ye-staging.yaml
@@ -7,15 +7,32 @@ on:
         required: true
         default: latest
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate docker image tag
+        id: inputs
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
+        run: |
+          tag="${DOCKER_IMAGE_TAG:-latest}"
+          if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid docker image tag: $tag" >&2
+            exit 1
+          fi
+          echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to yv-staging
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:
           host: ${{ secrets.YV_STAGING_HOST }}
           username: ${{ secrets.YV_STAGING_USERNAME }}
           key: ${{ secrets.YV_STAGING_KEY }}
           port: ${{ secrets.YV_STAGING_PORT }}
-          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/deploy.sh" -o deploy.sh && chmod +x deploy.sh && ./deploy.sh "${{ github.event.inputs.docker_image_tag }}" "$HOME/.env" "up" "https://staging.yearn.vision"
+          envs: DOCKER_IMAGE_TAG
+          script: curl "https://raw.githubusercontent.com/yearn/yearn-exporter/master/deploy.sh" -o deploy.sh && chmod +x deploy.sh && ./deploy.sh "$DOCKER_IMAGE_TAG" "$HOME/.env" "up" "https://staging.yearn.vision"

--- a/.github/workflows/tests.partners.on_pull_req.yaml
+++ b/.github/workflows/tests.partners.on_pull_req.yaml
@@ -1,7 +1,7 @@
 
 name: Test Partners
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
     types: [ labeled ]
     paths:
@@ -13,9 +13,12 @@ on:
       - '**/middleware.py'
       - '**/requirements.txt'
 
+permissions:
+  contents: read
+
 jobs:
   test_partners:
-    if: ${{ github.event.label.name == 'safe to test' }}
+    if: ${{ github.event.label.name == 'safe to test' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,18 +31,12 @@ jobs:
           path: ~/Library/Caches/pip
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
-        # Providers for all chains.
-        - network: mainnet
-          provider: WEB3_PROVIDER
-        - network: ftm-main
-          provider: FTM_WEB3_PROVIDER
       fail-fast: false
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
-          ref: ${{github.event.pull_request.head.sha}}
           persist-credentials: false
 
       - name: Setup Python (faster than using Python container)
@@ -75,8 +72,19 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       
-      - name: Setup brownie networks
-        run: brownie networks modify ${{ matrix.network }} host=${{ secrets[matrix.provider] }}
+      - name: Setup mainnet brownie network
+        if: ${{ matrix.network == 'mainnet' }}
+        env:
+          WEB3_PROVIDER: ${{ secrets.WEB3_PROVIDER }}
+        run: brownie networks modify mainnet host="$WEB3_PROVIDER"
+        # continue-on-error is needed because this step will raise an exception on Windows, but will still correctly set the host.
+        continue-on-error: true
+
+      - name: Setup Fantom brownie network
+        if: ${{ matrix.network == 'ftm-main' }}
+        env:
+          FTM_WEB3_PROVIDER: ${{ secrets.FTM_WEB3_PROVIDER }}
+        run: brownie networks modify ftm-main host="$FTM_WEB3_PROVIDER"
         # continue-on-error is needed because this step will raise an exception on Windows, but will still correctly set the host.
         continue-on-error: true
 


### PR DESCRIPTION
## Summary
- move partner PR tests from pull_request_target to pull_request and skip fork heads for the secret-bearing job
- validate workflow_dispatch docker tag/network inputs before SSH/deploy commands use them
- pass validated values through environment variables instead of direct shell interpolation
- add read-only workflow permissions and remove dynamic secrets indexing

## Validation
- ruby YAML parse over changed workflows
- uvx zizmor --offline --min-severity medium on changed workflows: targeted template-injection, overprovisioned-secrets, and excessive-permissions findings are cleared
- remaining zizmor findings are existing unpinned action refs and workflow_run trigger warnings