### PR TITLE
Pin exporter SSH deploy actions

### DIFF
--- a/.github/workflows/debug-apy-prod.yaml
+++ b/.github/workflows/debug-apy-prod.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
           echo "network=$network" >> "$GITHUB_OUTPUT"
       - name: Debug APY on production
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         env:
           DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
           NETWORK: ${{ steps.inputs.outputs.network }}

--- a/.github/workflows/deploy-apy-prod.yaml
+++ b/.github/workflows/deploy-apy-prod.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
           echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to apy production
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         env:
           DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:

--- a/.github/workflows/deploy-revenues-prod.yaml
+++ b/.github/workflows/deploy-revenues-prod.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
           echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to revenues production
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         env:
           DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:

--- a/.github/workflows/deploy-ye-prod.yaml
+++ b/.github/workflows/deploy-ye-prod.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
           echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to yv-production
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         env:
           DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:

--- a/.github/workflows/deploy-ye-staging.yaml
+++ b/.github/workflows/deploy-ye-staging.yaml
@@ -26,7 +26,7 @@ jobs:
           fi
           echo "docker_image_tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Deploy to yv-staging
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         env:
           DOCKER_IMAGE_TAG: ${{ steps.inputs.outputs.docker_image_tag }}
         with:


### PR DESCRIPTION
Pin exporter SSH deploy actions to immutable commits.

Notes:
- Replaces moving `appleboy/ssh-action@master` refs in production, staging, and debug deploy workflows.
- Reduces supply-chain exposure in workflows with SSH deployment secrets.
- Validated touched workflows with PyYAML and git diff --check.

Related issue # (if applicable):

### What I did:

### How I did it:

### How to verify it:

### Checklist:
- [ ] I have tested it locally and it works
- [ ] I have included any relevant documentation for the repo maintainers
- [ ] (If fixing a bug) I have added a test to the test suite to test for this particular bug

#### Adding a Network
If the purpose of your PR is to add support for a new network, please copy the checklist from [here](https://github.com/yearn/yearn-exporter/blob/master/.github/new_network.md) into this PR conversation, and use it to track your changes.
